### PR TITLE
Allow output dest to be specified in exports

### DIFF
--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -1505,6 +1505,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
   public async htmlExport({
     offline = false,
     runAllCodeChunks = false,
+    dest = null,
   }): Promise<string> {
     const inputString = await utility.readFile(this.filePath, {
       encoding: "utf-8",
@@ -1528,9 +1529,8 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       embedSVG = htmlConfig["embed_svg"];
     }
 
-    let dest = this.filePath;
-    const extname = path.extname(dest);
-    dest = dest.replace(new RegExp(extname + "$"), ".html");
+    const extname = path.extname(this.filePath);
+    dest = dest || this.filePath.replace(new RegExp(extname + "$"), ".html");
 
     html = await this.generateHTMLTemplateForExport(html, yamlConfig, {
       isForPrint: false,
@@ -1575,6 +1575,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     fileType = "pdf",
     runAllCodeChunks = false,
     openFileAfterGeneration = false,
+    dest = null,
   }): Promise<string> {
     const inputString = await utility.readFile(this.filePath, {
       encoding: "utf-8",
@@ -1587,9 +1588,9 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       isForPreview: false,
       runAllCodeChunks,
     }));
-    let dest = this.filePath;
-    const extname = path.extname(dest);
-    dest = dest.replace(new RegExp(extname + "$"), "." + fileType);
+    const extname = path.extname(this.filePath);
+    dest =
+      dest || this.filePath.replace(new RegExp(extname + "$"), "." + fileType);
 
     html = await this.generateHTMLTemplateForExport(html, yamlConfig, {
       isForPrint: true,
@@ -1667,6 +1668,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     fileType = "pdf",
     runAllCodeChunks = false,
     openFileAfterGeneration = false,
+    dest = null,
   }): Promise<string> {
     const inputString = await utility.readFile(this.filePath, {
       encoding: "utf-8",
@@ -1679,9 +1681,9 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       isForPreview: false,
       runAllCodeChunks,
     }));
-    let dest = this.filePath;
-    const extname = path.extname(dest);
-    dest = dest.replace(new RegExp(extname + "$"), "." + fileType);
+    const extname = path.extname(this.filePath);
+    dest =
+      dest || this.filePath.replace(new RegExp(extname + "$"), "." + fileType);
 
     html = await this.generateHTMLTemplateForExport(html, yamlConfig, {
       isForPrint: true,
@@ -1744,6 +1746,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
   public async princeExport({
     runAllCodeChunks = false,
     openFileAfterGeneration = false,
+    dest = null,
   }): Promise<string> {
     const inputString = await utility.readFile(this.filePath, {
       encoding: "utf-8",
@@ -1756,9 +1759,8 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       isForPreview: false,
       runAllCodeChunks,
     }));
-    let dest = this.filePath;
-    const extname = path.extname(dest);
-    dest = dest.replace(new RegExp(extname + "$"), ".pdf");
+    const extname = path.extname(this.filePath);
+    dest = dest || this.filePath.replace(new RegExp(extname + "$"), ".pdf");
 
     html = await this.generateHTMLTemplateForExport(html, yamlConfig, {
       isForPrint: true,
@@ -1827,12 +1829,14 @@ sidebarTOCBtn.addEventListener('click', function(event) {
   public async eBookExport({
     fileType = "epub",
     runAllCodeChunks = false,
+    dest = null,
   }: {
     /**
      * fileType: 'epub', 'pdf', 'mobi' or 'html'
      */
     fileType: string;
     runAllCodeChunks?: boolean;
+    dest?: string;
   }): Promise<string> {
     const inputString = await utility.readFile(this.filePath, {
       encoding: "utf-8",
@@ -1848,12 +1852,13 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       emojiToSvg,
     }));
 
-    let dest = this.filePath;
-    const extname = path.extname(dest);
-    dest = dest.replace(
-      new RegExp(extname + "$"),
-      "." + fileType.toLowerCase(),
-    );
+    const extname = path.extname(this.filePath);
+    dest =
+      dest ||
+      this.filePath.replace(
+        new RegExp(extname + "$"),
+        "." + fileType.toLowerCase(),
+      );
 
     const ebookConfig = yamlConfig["ebook"];
     if (!ebookConfig) {


### PR DESCRIPTION
Hi,

I wanted to address #73. I added a `dest` parameter to all export functions except `markdownExport` and `pandocExport` as those can already be configured via frontmatter. If you want those functions to have explicit `dest` parameters as well it should be no problem to add these.

Another issue right now is that `dest` does not get expanded, so `dest = '~/test.html'` is not expanded to `/home/[USER]/test.html`. I don't know wheter or not expanding paths is desired behavior, so I left it out for now.

Please let me know what you think and if I should change something!

Cheers,
Till