### PR TITLE
Class-notation to determine plantuml-language in markdown-preview-enhanced

### DIFF
--- a/src/lib/block-info/parse.ts
+++ b/src/lib/block-info/parse.ts
@@ -5,6 +5,7 @@ export default function(raw: string): BlockInfo {
   let language;
   let attributesAsString: string;
   let attributes: object;
+  const supportedLanguages = ["plantuml", "puml"]
   const trimmedParams = raw.trim();
   const match =
     trimmedParams.indexOf("{") !== -1
@@ -29,6 +30,11 @@ export default function(raw: string): BlockInfo {
     }
   } else {
     attributes = {};
+  }
+  if(!language && attributes && attributes.hasOwnProperty("class")){
+      if(supportedLanguages.indexOf(attributes["class"]) !== -1){
+          language = attributes["class"];
+      }
   }
 
   return { language, attributes };

--- a/src/lib/block-info/parse.ts
+++ b/src/lib/block-info/parse.ts
@@ -5,7 +5,7 @@ export default function(raw: string): BlockInfo {
   let language;
   let attributesAsString: string;
   let attributes: object;
-  const supportedLanguages = ["plantuml", "puml"]
+  const supportedLanguages = ["plantuml", "puml"];
   const trimmedParams = raw.trim();
   const match =
     trimmedParams.indexOf("{") !== -1
@@ -31,10 +31,10 @@ export default function(raw: string): BlockInfo {
   } else {
     attributes = {};
   }
-  if(!language && attributes && attributes.hasOwnProperty("class")){
-      if(supportedLanguages.indexOf(attributes["class"]) !== -1){
-          language = attributes["class"];
-      }
+  if (!language && attributes && attributes.hasOwnProperty("class")) {
+    if (supportedLanguages.indexOf(attributes["class"]) !== -1) {
+      language = attributes["class"];
+    }
   }
 
   return { language, attributes };


### PR DESCRIPTION
I want to be able to preview plantuml diagramms in vscode-markdown-extension and using [pandoc-plantuml-filter](https://github.com/timofurrer/pandoc-plantuml-filter) including caption and further attributes in pandoc process chain.

Currently it is only possible to annotate the code fences directly with the language (i.e. `plantuml` or `plantuml {attributes}`).
Especially the second form is not supported in my pandoc setup.

This push request should allow to use the class form as language annotation for code fences (i.e. `{.plantuml caption="Some Caption"}`). 

~~~
# Header 

## PlantUML-Integration

### Identifier

This is currently working.

```plantuml
Alice -> Bob: los()

```

### Als Class

This is currently not working in Preview Markdown and should be solved by this push request.

``` {.plantuml caption="Test-Beschriftung" #fig:fig-beschriftung}
@startuml
Alice -> Bob: los()
@enduml
```


### As Identifier with caption

This is working in markdown-preview-enhanced but not in pandoc with [pandoc-plantuml-filter](https://github.com/timofurrer/pandoc-plantuml-filter) and is also not recognized as code block in [pandoc-filter](https://pandoc.org/filters.html).

``` plantuml {caption="Test-Beschriftung" #fig:fig-beschriftung}
Alice -> Bob: los()

```


~~~~