### PR TITLE
Fix codeBlock html tag

### DIFF
--- a/src/custom-markdown-it-features/code-fences.ts
+++ b/src/custom-markdown-it-features/code-fences.ts
@@ -30,6 +30,6 @@ export default (md: MarkdownIt) => {
       JSON.stringify(parsedInfo),
     )}" data-normalized-info="${escape(
       JSON.stringify(normalizedInfo),
-    )}">${content}</pre>${finalBreak}`;
+    )}"><code>${content}</code></pre>${finalBreak}`;
   };
 };


### PR DESCRIPTION
Code blocks should be included in `<pre><code>`, where `<code>` is indispensable for best compatibility.