### PR TITLE
fix: ajust the styles for preview

### DIFF
--- a/styles/preview_theme/github.less
+++ b/styles/preview_theme/github.less
@@ -3,7 +3,7 @@
   @fg-strong: contrast(@bg, darken(@fg, 32%), lighten(@fg, 32%));
   @fg-subtle: contrast(@fg, lighten(@fg, 16%), darken(@fg, 16%));
   @border: contrast(@bg, lighten(@bg, 16%), darken(@bg, 16%));
-  @blockquote-bg: contrast(@bg, lighten(@bg, 8%), darken(@bg, 6%));
+  @blockquote-bg: transparent;
   @margin: 16px;
 
   body {
@@ -186,7 +186,7 @@
       padding: 0 15px;
       color: @fg-subtle;
       background-color: @blockquote-bg;
-      border-left: 4px solid @border;
+      border-left: 0.25rem solid @border;
 
       > :first-child {
         margin-top: 0;

--- a/styles/prism_theme/vue.less
+++ b/styles/prism_theme/vue.less
@@ -156,7 +156,6 @@
   line-height: 2em;
   // margin: 16px 2px;
   max-width: inherit;
-  overflow: inherit;
   padding: 0.8em 1.4em;
   white-space: pre;
 }


### PR DESCRIPTION
Hi!I found that the content of code block overflowed when using the vue preview theme.This is because tag `pre`'s overflow property is set to inherit.I tried to delete the property and then everything goes well.Besides,one thing that has always bothering me is the inline code block's background color is the same as the blockquote's,which makes the inline code blocks look really strange in blockquote.So just like the github markdown preview theme now.I set the  blockquote's background to transaprent and set the blockquote's border width to 0.25rem.