### PR TITLE
doc: Add coc.nvim to error information

### DIFF
--- a/src/renderers/puml.ts
+++ b/src/renderers/puml.ts
@@ -140,7 +140,7 @@ ${content}
 Please download plantuml.jar from https://plantuml.com/download.  
 ${plantumlJarPath ? `Then please put it at "${plantumlJarPath}"` : ``}
 
-If you are using VSCode, then please set the setting "markdown-preview-enhanced.plantumlJarPath" to the absolute path of plantuml.jar file. 
+If you are using VSCode or coc.nvim, then please set the setting "markdown-preview-enhanced.plantumlJarPath" to the absolute path of plantuml.jar file.
 
 If you don't want to use plantuml.jar, then you can use the online plantuml server 
 by setting the setting "markdown-preview-enhanced.plantumlServer" to the URL of the online plantuml server, for example: https://kroki.io/plantuml/svg/


### PR DESCRIPTION
I met this error in <https://github.com/weirongxu/coc-markdown-preview-enhanced>, so I update the error information to let other vim user to know what happened.
