### PR TITLE
fix: long sidebarToc does not display completely

### DIFF
--- a/styles/preview.less
+++ b/styles/preview.less
@@ -52,7 +52,7 @@ body {
       right: 0;
       width: 268px;
       height: 100%;
-      padding: 32px 0 12px 0;
+      padding: 32px 0;
       overflow: auto;
       background-color: @bg;
       // color: @fg;


### PR DESCRIPTION
When the sidebarToc is too long, it does not display completely.

![CleanShot 2024-03-12 at 18 50 18](https://github.com/shd101wyy/crossnote/assets/22940470/20c22b4d-04c3-4141-a150-3c7be02dbf07)

After：

![CleanShot 2024-03-12 at 18 51 26](https://github.com/shd101wyy/crossnote/assets/22940470/5dd3f7f0-4366-4922-b96b-8374984a100a)

But I'm unsure if the modifications consider all scenarios.


[test.md](https://github.com/shd101wyy/crossnote/files/14571165/test.md)

