### PR TITLE
Fix splitting logic to handle diagrams starting with `<svg>` correctly.

### DIFF
--- a/src/renderers/puml.ts
+++ b/src/renderers/puml.ts
@@ -69,15 +69,18 @@ class PlantUMLTask {
       ) {
         data = this.chunks;
         this.chunks = ''; // clear CHUNKS
-        const diagrams = data.split('<?xml ');
-        diagrams.forEach((diagram) => {
-          if (diagram.length) {
-            const callback = this.callbacks.shift();
-            if (callback) {
-              callback(diagram.startsWith('<') ? diagram : '<?xml ' + diagram);
+        const regex = /<svg[^>]*>[\s\S]*?<\/svg>/g;
+        const diagrams = data.match(regex);
+        if ( diagrams != null ) {
+          diagrams.forEach((diagram) => {
+            if (diagram.length) {
+              const callback = this.callbacks.shift();
+              if (callback) {
+                callback(diagram.startsWith('<') ? diagram : '<svg ' + diagram);
+              }
             }
-          }
-        });
+          });
+        }
       }
     });
 


### PR DESCRIPTION
This PR fixes the bug reported in [#376](https://github.com/shd101wyy/crossnote/issues/376) (Related to https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2087), where PlantUML diagrams starting with `<svg>` were not displayed correctly.

**Background**
In `puml.ts`, the `startTask` function is intended to split the PlantUML `stdout` stream at `<svg>` boundaries and resolve each corresponding callback.
However, the actual code was splitting at `<?xml>` instead, breaking the mapping between input `content` and callbacks when multiple diagrams were returned.
This caused:
- Diagrams to appear in the wrong order or position
- Some `resolve` callbacks never being called, causing the process to hang

**Cause**
Older versions of PlantUML (`-tsvg` output) started with `<?xml>`, but newer versions (e.g., `plantuml-mit-1.2025.4.jar`) now output `<svg>` directly.  
The splitting logic was not updated accordingly.

**Fix**
- Adjust the splitting logic to correctly handle output starting with `<svg>`.

**Tested**
Verified locally on:
- Windows 11
- Crossnote 0.9.14
- PlantUML plantuml-mit-1.2025.4.jar
Multiple diagrams are now rendered in correct order without hangs.

Commit included:
- `Fix splitting logic to handle diagrams starting with <svg> correctly.`

