### PR TITLE
fix(callout): preserve formatted title rendering

### DIFF
--- a/src/custom-markdown-it-features/callout.ts
+++ b/src/custom-markdown-it-features/callout.ts
@@ -110,9 +110,15 @@ export default (md: MarkdownIt) => {
             match[2] === '+' ? 'open' : match[2] === '-' ? 'closed' : null;
           title = match[3] || '';
 
-          // remove the callout marker and "\n" from the inline token's children
+          // Remove the complete marker/title line, which may span several
+          // inline tokens when the title contains Markdown formatting.
+          const titleEnd = textToken.children?.findIndex(
+            (child) => child.type === 'softbreak' || child.type === 'hardbreak',
+          );
           textToken.children =
-            textToken.children?.filter((_, i) => i > 1) || null;
+            titleEnd === undefined || titleEnd === -1
+              ? null
+              : textToken.children?.slice(titleEnd + 1) || null;
 
           const remainingChildren = textToken.children;
           const isEmptyParagraph =
@@ -148,13 +154,13 @@ export default (md: MarkdownIt) => {
       if (foldable) {
         const openAttr = foldable === 'open' ? ' open' : '';
         let html = `<details class="callout" data-callout="${calloutType}"${openAttr}>\n`;
-        html += `<summary class="callout-title">${md.utils.escapeHtml(displayTitle)}</summary>\n`;
+        html += `<summary class="callout-title">${md.renderInline(displayTitle, env)}</summary>\n`;
         return html;
       }
 
       let html = `<div class="callout" data-callout="${calloutType}">\n`;
       if (displayTitle) {
-        html += `<div class="callout-title">${md.utils.escapeHtml(displayTitle)}</div>\n`;
+        html += `<div class="callout-title">${md.renderInline(displayTitle, env)}</div>\n`;
       }
       return html;
     } else {

--- a/styles/markdown-it-callout.css
+++ b/styles/markdown-it-callout.css
@@ -23,6 +23,14 @@
   color: rgb(var(--callout-color));
 }
 
+.callout>.callout-title * {
+  color: inherit;
+}
+
+.callout>.callout-title a {
+  text-decoration: underline;
+}
+
 .callout .callout-title::before {
   position: absolute;
   left: 1.2rem;

--- a/test/callout.test.ts
+++ b/test/callout.test.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Notebook } from '../src/notebook/index';
+
+describe('callouts', () => {
+  let tmp: string;
+  let notebook: Notebook;
+
+  const parse = async (markdown: string) => {
+    const filePath = path.join(tmp, 'note.md');
+    fs.writeFileSync(filePath, markdown);
+    const engine = notebook.getNoteMarkdownEngine(filePath);
+    return engine.parseMD(markdown, {
+      useRelativeFilePath: false,
+      isForPreview: true,
+      hideFrontMatter: false,
+    });
+  };
+
+  beforeAll(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'callout-'));
+    notebook = await Notebook.init({
+      notebookPath: tmp,
+      config: { markdownParser: 'markdown-it' },
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('renders formatted titles without leaking them into the body', async () => {
+    const { html } = await parse(
+      '> [!note] Example `[!note]` **Callout**\n> Example content\n',
+    );
+
+    expect(html).toContain('<div class="callout" data-callout="note">');
+    expect(html).toContain(
+      '<div class="callout-title">Example <code>[!note]</code> <strong>Callout</strong></div>',
+    );
+    expect(html).toMatch(/<p[^>]*>Example content<\/p>/);
+  });
+
+  it('renders formatted titles for foldable callouts', async () => {
+    const { html } = await parse('> [!tip]+ **More** details\n> Body\n');
+
+    expect(html).toContain(
+      '<details class="callout" data-callout="tip" open="">',
+    );
+    expect(html).toContain(
+      '<summary class="callout-title"><strong>More</strong> details</summary>',
+    );
+    expect(html).toMatch(/<p[^>]*>Body<\/p>/);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes inline formatting in callout titles.

Previously, the renderer assumed that the callout marker and title always occupied a fixed number of
inline tokens. As a result, titles containing inline code, bold text, or links could lose formatting
and leak part of the title into the callout body.

For example:

```markdown
> [!note] Example `[!note]` **Callout**
> Example content
```

The title is now rendered correctly, the body no longer contains leftover title text, and inline
elements inherit the callout title color.

## Changes

- Detect the actual title/body boundary using soft and hard breaks.
- Render callout titles with Markdown inline formatting.
- Keep formatted title elements consistent with the callout color.
- Add regression tests for formatted and foldable callouts.

## Tests

- pnpm test -- callout.test.ts
- pnpm check:tsc
- ESLint
- Prettier

Refs: https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1911#issuecomment-5294139166