### PR TITLE
ci: manual-dispatch release workflow with automated version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,4 @@ jobs:
             --head "release/v$NEW_VERSION" \
             --title "chore: release v$NEW_VERSION" \
             --body "Automated version bump and changelog update for v$NEW_VERSION."
-
-      # develop requires 1 approving review; the bot can't approve its own PR,
-      # so RELEASE_TOKEN (a PAT of the maintainer) supplies the approval
-      - name: Approve and auto-merge the release PR
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
-        run: |
-          gh pr review "release/v$NEW_VERSION" --approve \
-            --body "Automated approval for release v$NEW_VERSION."
           gh pr merge "release/v$NEW_VERSION" --auto --merge --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   publish:
@@ -100,5 +101,15 @@ jobs:
             --notes "$RELEASE_NOTES" \
             --target master
 
-      - name: Sync release commit back to develop
-        run: git push origin HEAD:develop
+      - name: Open auto-merge PR back to develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          git push origin "HEAD:refs/heads/release/v$NEW_VERSION"
+          gh pr create \
+            --base develop \
+            --head "release/v$NEW_VERSION" \
+            --title "chore: release v$NEW_VERSION" \
+            --body "Automated version bump and changelog update for v$NEW_VERSION." \
+          && gh pr merge --auto --merge --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: 'Version bump level'
+        description: "Version bump level"
         required: true
-        default: 'patch'
+        default: "patch"
         type: choice
         options:
           - patch
@@ -36,7 +36,7 @@ jobs:
         with:
           cache: pnpm
           node-version-file: .tool-versions
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,4 +114,14 @@ jobs:
             --head "release/v$NEW_VERSION" \
             --title "chore: release v$NEW_VERSION" \
             --body "Automated version bump and changelog update for v$NEW_VERSION."
+
+      # develop requires 1 approving review; the bot can't approve its own PR,
+      # so RELEASE_TOKEN (a PAT of the maintainer) supplies the approval
+      - name: Approve and auto-merge the release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          gh pr review "release/v$NEW_VERSION" --approve \
+            --body "Automated approval for release v$NEW_VERSION."
           gh pr merge "release/v$NEW_VERSION" --auto --merge --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,15 @@ jobs:
           NEW_VERSION=$(npm version ${{ inputs.bump }} --no-git-tag-version)
           echo "new-version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Update CHANGELOG.md
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          TODAY=$(date +%F)
+          # rename [Unreleased] to the new version and prepend a fresh [Unreleased] section
+          perl -0pi -e "s/^## \[Unreleased\]\n/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] - $ENV{TODAY}\n/m" CHANGELOG.md
+          grep -q "## \[$NEW_VERSION\] - $TODAY" CHANGELOG.md
+
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2.0.0
@@ -69,7 +78,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
         run: |
-          git add package.json
+          git add package.json CHANGELOG.md
           git commit -m "$NEW_VERSION"
           git tag "$NEW_VERSION"
           git push origin HEAD:master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,21 @@
 name: Publish a package to the npm registry
 
 on:
-  push:
-    branches:
-      - master
-      - develop
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump level'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+
+permissions:
+  contents: write
 
 jobs:
   publish:
@@ -12,6 +23,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
+        with:
+          # full history so we can push a release commit to master and develop
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -21,40 +35,61 @@ jobs:
         with:
           cache: pnpm
           node-version-file: .tool-versions
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint and typecheck
+        run: pnpm run check
+
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm run build
 
-      - name: Get current package version
-        id: package_version
-        uses: martinbeentjes/npm-get-version-action@v1.1.0
+      - name: Bump version
+        id: bump
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          NEW_VERSION=$(npm version ${{ inputs.bump }} --no-git-tag-version)
+          echo "new-version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2.0.0
-
         with:
           validation_level: warn
-          version: ${{ steps.package_version.outputs.current-version }}
+          version: ${{ steps.bump.outputs.new-version }}
           path: CHANGELOG.md
 
+      - name: Commit, tag and push
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          git add package.json
+          git commit -m "$NEW_VERSION"
+          git tag "$NEW_VERSION"
+          git push origin HEAD:master
+          git push origin "refs/tags/$NEW_VERSION"
+
       - name: Publish package
-        if: github.ref == 'refs/heads/master'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create a Release
-        if: github.ref == 'refs/heads/master'
-        id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.package_version.outputs.current-version}}
-          release_name: ${{ steps.package_version.outputs.current-version}}
-          body: ${{ steps.changelog_reader.outputs.changes }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+          RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
+        run: |
+          gh release create "$NEW_VERSION" \
+            --title "$NEW_VERSION" \
+            --notes "$RELEASE_NOTES" \
+            --target master
+
+      - name: Sync release commit back to develop
+        run: git push origin HEAD:develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,12 @@ jobs:
           version: ${{ steps.bump.outputs.new-version }}
           path: CHANGELOG.md
 
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # prerelease versions must not become the npm 'latest' dist-tag
+        run: npm publish $(if [ '${{ inputs.bump }}' = 'prerelease' ]; then echo '--tag next'; fi)
+
       - name: Commit, tag and push
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
@@ -85,11 +91,6 @@ jobs:
           git push origin HEAD:master
           git push origin "refs/tags/$NEW_VERSION"
 
-      - name: Publish package
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create a Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +100,8 @@ jobs:
           gh release create "$NEW_VERSION" \
             --title "$NEW_VERSION" \
             --notes "$RELEASE_NOTES" \
-            --target master
+            --target master \
+            $(if [ '${{ inputs.bump }}' = 'prerelease' ]; then echo '--prerelease'; fi)
 
       - name: Open auto-merge PR back to develop
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,5 +113,15 @@ jobs:
             --base develop \
             --head "release/v$NEW_VERSION" \
             --title "chore: release v$NEW_VERSION" \
-            --body "Automated version bump and changelog update for v$NEW_VERSION." \
-          && gh pr merge --auto --merge --delete-branch
+            --body "Automated version bump and changelog update for v$NEW_VERSION."
+
+      # develop requires 1 approving review; the bot can't approve its own PR,
+      # so RELEASE_TOKEN (a PAT of the maintainer) supplies the approval
+      - name: Approve and auto-merge the release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          gh pr review "release/v$NEW_VERSION" --approve \
+            --body "Automated approval for release v$NEW_VERSION."
+          gh pr merge "release/v$NEW_VERSION" --auto --merge --delete-branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,30 @@ Crossnote is the core markdown rendering engine behind the **Markdown Preview En
 - Fix: `pnpm fix` (auto-fix ESLint + Prettier)
 - Always run `pnpm check && pnpm test` before committing
 
+## Release Process
+
+Releases are automated via [`.github/workflows/release.yml`](.github/workflows/release.yml), triggered manually (**workflow_dispatch**) with a `bump` level of `patch` / `minor` / `major` / `prerelease`. Do **not** bump `package.json` or cut tags by hand.
+
+What the workflow does, in order:
+
+1. Runs `pnpm check`, `pnpm test`, `pnpm build`
+2. Bumps `package.json` (`npm version <level>`)
+3. Rewrites `CHANGELOG.md`: renames `## [Unreleased]` to `## [X.Y.Z] - <today>` and prepends a fresh empty `## [Unreleased]` section — **write changelog entries under `[Unreleased]` before dispatching a release**
+4. Publishes to npm (`prerelease` bumps go to the `next` dist-tag, never `latest`)
+5. Commits the bump, tags it, pushes to `master` + tag, creates the GitHub Release with the changelog entry
+6. Opens a `release/vX.Y.Z` → `develop` PR, approves it via the `RELEASE_TOKEN` secret, and auto-merges it
+
+### Branch protection on `develop`
+
+- Classic branch protection: requires a PR + **1 approving review** before merging; admins (the maintainer) may merge without waiting via "Merge without waiting for requirements"
+- No force pushes or deletions; conversation resolution required
+- The release PR satisfies the review requirement through the `RELEASE_TOKEN` secret — a fine-grained PAT of the maintainer (Contents + Pull requests: read/write on this repo only). If the token expires, the release PR will stall at the approval step; rotate it and re-run the failed job.
+
+### Notes
+
+- The `Test` workflow does not run on pushes to `master`; releases run their own full check/test/build in the release workflow
+- Workflow pushes use the default `GITHUB_TOKEN`, which does not re-trigger push-based workflows (no recursion)
+
 ## Security Requirements
 
 This project processes untrusted markdown content that may contain malicious HTML. **All HTML output must be sanitized before DOM insertion.**


### PR DESCRIPTION
## Summary

Replaces the push-to-master release trigger with a manual `workflow_dispatch` workflow, so releasing is one click with a `bump` level choice (patch / minor / major / prerelease) instead of a hand-edited `package.json` and a push to master.

What the workflow does, in order:

1. Runs `pnpm check`, `pnpm test`, and `pnpm build` — nothing publishes from a broken tree.
2. Bumps `package.json` with `npm version <level> --no-git-tag-version`.
3. Rewrites `CHANGELOG.md`: renames `## [Unreleased]` to `## [X.Y.Z] - <today>` and prepends a fresh empty `## [Unreleased]` section (Keep-a-Changelog convention). Fails loudly if no `[Unreleased]` header is found.
4. Publishes to npm **before** moving any git refs, so a failed publish leaves master and tags untouched. Prerelease bumps are published with `--tag next` so they never become `latest`.
5. Commits the version bump **and the CHANGELOG rewrite**, tags the new version, and pushes the commit + tag to `master`.
6. Creates the GitHub Release with the changelog entry (marked `--prerelease` for prerelease bumps); uses `gh` CLI instead of the archived `actions/create-release`.
7. Pushes the same commit to a temporary `release/vX.Y.Z` branch and opens a PR into `develop`. develop's classic branch protection requires 1 approving review, which the bot can't give itself, so the PR is approved with the `RELEASE_TOKEN` secret (a maintainer PAT) and then auto-merged (repo auto-merge is enabled).

## Notes

- Workflow pushes use the default `GITHUB_TOKEN`, which deliberately won't re-trigger push-based workflows (prevents recursion); publish/release happen in the same run.
- develop branch protection stays as classic protection (PR + 1 approving review before merging; admins may merge without waiting; no force pushes or deletions).
- `AGENTS.md` gains a "Release Process" section documenting the dispatch flow, the `[Unreleased]` changelog convention, and `RELEASE_TOKEN` rotation.