### PR TITLE
fix: reject sibling-directory prefix bypass in test server traversal guard

### DIFF
--- a/test/browser-server-guard.test.ts
+++ b/test/browser-server-guard.test.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+import { isPathWithinRoot } from './browser/server';
+
+describe('isPathWithinRoot (test server traversal guard)', () => {
+  const root = path.resolve('/srv/static/mathjax');
+
+  it('accepts the root itself and files inside it', () => {
+    expect(isPathWithinRoot(root, root)).toBe(true);
+    expect(isPathWithinRoot(root, path.join(root, 'tex-svg.js'))).toBe(true);
+    expect(isPathWithinRoot(root, path.join(root, 'a', 'b', 'c.js'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects parent traversal outside the root', () => {
+    expect(isPathWithinRoot(root, path.resolve(root, '../secret.txt'))).toBe(
+      false,
+    );
+    expect(
+      isPathWithinRoot(root, path.resolve(root, '../../../etc/passwd')),
+    ).toBe(false);
+  });
+
+  it("rejects sibling directories sharing the root's name prefix", () => {
+    // `resolve(root, '../mathjax-evil/x')` lands in a sibling directory whose
+    // path still starts with the root string — the old `startsWith(root)`
+    // check let it through.
+    expect(
+      isPathWithinRoot(root, path.resolve(root, '../mathjax-evil/x')),
+    ).toBe(false);
+  });
+});

--- a/test/browser/server.ts
+++ b/test/browser/server.ts
@@ -29,6 +29,15 @@ export interface TestServer {
 }
 
 /**
+ * Whether `candidate` is `root` itself or located underneath it. The
+ * separator must be part of the check, otherwise a sibling directory that
+ * merely shares a name prefix (`<root>-evil`) passes.
+ */
+export function isPathWithinRoot(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+/**
  * Serve a blank preview page at `/` and the locally installed MathJax 4
  * package under `/mathjax/...` over real HTTP (so the speech-rule-engine's
  * web worker, which won't run from a `file://` origin, works as it does in the
@@ -54,7 +63,7 @@ export async function startServer(): Promise<TestServer> {
       const rel = decodeURIComponent(url.slice(mount.prefix.length));
       // Resolve within the mount root and refuse path traversal.
       const filePath = path.resolve(mount.root, rel);
-      if (!filePath.startsWith(mount.root)) {
+      if (!isPathWithinRoot(mount.root, filePath)) {
         res.writeHead(403);
         res.end('forbidden');
         return;


### PR DESCRIPTION
Hardening found during a security-gate review of flagged findings. This was the only true positive among them.

## Issue

The Playwright test server (`test/browser/server.ts`) guards static mounts with `filePath.startsWith(mount.root)` without a trailing path separator. A request like `/mathjax/../mathjax-evil/x` resolves into a *sibling* directory whose path still shares the root's name prefix, so the guard passed and the file was served. (Localhost-only dev server — low severity, but a real boundary check bug.)

## Fix

Extract `isPathWithinRoot()` which requires `root + path.sep` (or an exact `root` match) and use it in the request handler. Unit tests in `test/browser-server-guard.test.ts` cover: root/inside accepted, parent traversal rejected, and the sibling-prefix bypass rejected. (`test/browser/` is excluded from Jest as the Playwright suite, hence the test living at `test/` root.)

Lint, typecheck and the guard tests pass.