### PR TITLE
feat(security): host-only previewScriptsEnabled flag + hardened script emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ Please visit https://github.com/shd101wyy/vscode-markdown-preview-enhanced/relea
 
 ### Features
 
+- **Explicit opt-in channel for user preview scripts (`notebook.previewScriptsEnabled`)** — Host applications can now set `Notebook.previewScriptsEnabled = true` to re-enable custom preview JavaScript that [0.9.31](#0931---2026-06-08) disabled ([#446](https://github.com/shd101wyy/crossnote/issues/446)). When opted in, `<script src="./copy-buttons.js">` tags in `.crossnote/head.html` are kept and rewritten to file URLs, and `@import "*.js"` file imports are emitted again. The channel is file-based and workspace-scoped: inline scripts, URL-scheme sources (`https://`, `file://`, `data:`, …), and paths resolving outside the notebook directory (symlinks included) are always removed. The flag is deliberately **not** part of `NotebookConfig` — `.crossnote/config.js` is untrusted repository content and can never turn it on; only the host (e.g. an application-scope VS Code setting) can. HTML/eBook exports continue to strip all scripts unconditionally.
 - **Add a translation toggle to the preview context menu** — The webview now reads an `isShowingTranslation` flag from `WebviewConfig` (passed by the host via `initPreview`'s `<meta data-config>`, so it survives webview reloads) and renders a context-menu item that switches between "Translate" and "Show Original". Clicking it posts `translateDocument` or `restoreOriginal` back to the host, which drives the AI translation feature in the `vscode-markdown-preview-enhanced` extension.
+
+### Security
+
+- **Harden `@import "*.js"` script emission in the preview webview** — `generateJSAndCssFilesForPreview()` used to emit `<script src>` tags for any collected path, including remote `https?://` URLs written in note content (reachable when `enableScriptExecution` was on). Script emission now additionally requires `notebook.previewScriptsEnabled`, rejects URL-scheme and protocol-relative sources, and confines resolved paths to the notebook directory (via `realpath`, so symlinks cannot escape). Stylesheet imports are unaffected.
 
 ### Updates
 

--- a/src/markdown-engine/index.ts
+++ b/src/markdown-engine/index.ts
@@ -717,6 +717,36 @@ window["initRevealPresentation"] = async function() {
   ) {
     let output = '';
     JSAndCssFiles.forEach((sourcePath) => {
+      // `@import "*.js"` in a note is untrusted content and used to load
+      // arbitrary scripts — including remote https:// URLs — into the
+      // preview webview, where they run before the React app and any
+      // CSP/DOMPurify defenses. Scripts are only emitted when the host
+      // application opted in via `notebook.previewScriptsEnabled`, and
+      // only for files that resolve inside the notebook directory.
+      // Stylesheets keep their original behavior.
+      if (sourcePath.endsWith('.js')) {
+        if (
+          !this.notebook.previewScriptsEnabled ||
+          sourcePath.startsWith('//') ||
+          /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(sourcePath)
+        ) {
+          return;
+        }
+        const resolvedPath =
+          sourcePath[0] === '/'
+            ? path.resolve(this.projectDirectoryPath.fsPath, '.' + sourcePath)
+            : path.resolve(this.fileDirectoryPath, sourcePath);
+        if (!this.isPathInsideProjectDirectory(resolvedPath)) {
+          return;
+        }
+        output += `<script type="text/javascript" src="${utility.addFileProtocol(
+          resolvedPath,
+          vscodePreviewPanel,
+        )}"></script>`;
+        return;
+      }
+
+      // css
       let absoluteFilePath = sourcePath;
       if (sourcePath[0] === '/') {
         absoluteFilePath = utility.addFileProtocol(
@@ -734,15 +764,34 @@ window["initRevealPresentation"] = async function() {
           vscodePreviewPanel,
         );
       }
-
-      if (absoluteFilePath.endsWith('.js')) {
-        output += `<script type="text/javascript" src="${absoluteFilePath}"></script>`;
-      } else {
-        // css
-        output += `<link rel="stylesheet" href="${absoluteFilePath}">`;
-      }
+      output += `<link rel="stylesheet" href="${absoluteFilePath}">`;
     });
     return output;
+  }
+
+  /**
+   * Whether an absolute filesystem path stays inside the notebook
+   * directory. Used to constrain user-provided preview scripts to
+   * workspace-local files — symlinks are resolved so a link inside the
+   * workspace cannot pull in a script from outside it.
+   */
+  private isPathInsideProjectDirectory(filePath: string): boolean {
+    const realpath = (p: string) => {
+      try {
+        return fs.realpathSync(p);
+      } catch {
+        return p;
+      }
+    };
+    const relative = path.relative(
+      realpath(this.projectDirectoryPath.fsPath),
+      realpath(filePath),
+    );
+    return (
+      relative !== '' &&
+      !relative.startsWith('..') &&
+      !path.isAbsolute(relative)
+    );
   }
 
   /**
@@ -859,7 +908,13 @@ window["initRevealPresentation"] = async function() {
           JSAndCssFiles,
           vscodePreviewPanel,
         )}
-        ${await this.resolvePathsInHeader(this.notebook.config.includeInHeader)}
+        ${await this.resolvePathsInHeader(
+          this.notebook.config.includeInHeader,
+          {
+            allowScripts: this.notebook.previewScriptsEnabled,
+            vscodePreviewPanel,
+          },
+        )}
         ${head}
       </head>
       <body class="preview-container ${
@@ -2412,21 +2467,58 @@ sidebarTOCBtn.addEventListener('click', function(event) {
   }
 
   // FIXME: This function actually doesn't help in the web version.
-  private async resolvePathsInHeader(header: string) {
+  private async resolvePathsInHeader(
+    header: string,
+    {
+      allowScripts = false,
+      vscodePreviewPanel = null as vscode.WebviewPanel | null | undefined,
+    }: {
+      allowScripts?: boolean;
+      vscodePreviewPanel?: vscode.WebviewPanel | null | undefined;
+    } = {},
+  ) {
     const $ = cheerio.load(header);
 
-    // Strip all <script> tags — head.html is workspace content that
-    // executes before the React app and any CSP/DOMPurify defenses,
-    // giving an attacker access to the webview's postMessage API.
-    // Users who need custom JavaScript in the preview should use
-    // extension-level APIs instead.
+    // head.html is workspace content that executes in the preview webview
+    // before the React app and any CSP/DOMPurify defenses, giving an
+    // attacker access to the webview's postMessage API. By default all
+    // <script> tags are removed; <style>, <meta>, and <link> tags are
+    // kept. When the host application explicitly opted in
+    // (`notebook.previewScriptsEnabled`), file-based scripts that resolve
+    // inside the notebook directory are kept and rewritten to file URLs —
+    // inline scripts and URL-scheme sources never run.
     //
     // NOTE: This helper is shared by the preview webview and the HTML /
     // eBook export paths, so scripts in head.html are stripped from
     // exported documents too — not just the webview that the advisory
     // (GHSA-mcwg-4j78-qwv3) covers. This is intentional hardening:
     // exported HTML running attacker-supplied JS is equally undesirable.
-    $('script').remove();
+    if (allowScripts) {
+      $('script').each((_i, element) => {
+        const src = $(element).attr('src');
+        if (
+          !src ||
+          src.startsWith('//') ||
+          /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(src)
+        ) {
+          $(element).remove();
+          return;
+        }
+        const resolvedPath = src.startsWith('/')
+          ? path.resolve(this.projectDirectoryPath.fsPath, '.' + src)
+          : path.resolve(this.fileDirectoryPath, src);
+        if (!this.isPathInsideProjectDirectory(resolvedPath)) {
+          $(element).remove();
+          return;
+        }
+        $(element).attr(
+          'src',
+          utility.addFileProtocol(resolvedPath, vscodePreviewPanel),
+        );
+      });
+    } else {
+      $('script').remove();
+    }
 
     // Return only the head content, not the full HTML structure
     return $('head').html() || header;

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -112,6 +112,18 @@ interface RefreshNotesInternalArgs extends RefreshNotesArgs {
 export class Notebook {
   public notebookPath!: URI;
   public config!: NotebookConfig;
+  /**
+   * Whether user-provided preview scripts may run in the preview webview:
+   * `<script src>` tags in `.crossnote/head.html` and `@import "*.js"`
+   * file imports. Defaults to `false`, which keeps both channels inert.
+   *
+   * SECURITY: deliberately NOT part of `NotebookConfig` — config values
+   * are merged from the repository's `.crossnote/config.js`, which is
+   * untrusted content. Only the host application may set this flag
+   * (e.g. from a user-scoped, application-scope setting); repository
+   * files must never be able to turn it on.
+   */
+  public previewScriptsEnabled: boolean = false;
   public fs!: FileSystemApi;
 
   public notes: Notes = {};

--- a/test/preview-scripts-gate.test.ts
+++ b/test/preview-scripts-gate.test.ts
@@ -1,0 +1,202 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { mkdirSync, track } from '../src/lib/temp';
+import { MarkdownEngine } from '../src/markdown-engine';
+import { Notebook } from '../src/notebook';
+import { WebviewConfig } from '../src/notebook/types';
+
+jest.mock('less', () => ({
+  render: (
+    _input: string,
+    _options: unknown,
+    callback: (error: unknown, output: { css: string } | undefined) => void,
+  ) => {
+    callback(null, { css: '' });
+  },
+}));
+
+/**
+ * Helper to render the preview template of a standalone note and return
+ * the generated HTML.
+ */
+async function renderPreviewTemplate(
+  notebook: Notebook,
+  filePath: string,
+  inputString: string,
+): Promise<string> {
+  const engine = new MarkdownEngine({ notebook, filePath });
+  const webviewConfig: WebviewConfig = notebook.config as WebviewConfig;
+  return engine.generateHTMLTemplateForPreview({
+    inputString,
+    config: webviewConfig,
+    vscodePreviewPanel: null,
+  });
+}
+
+/**
+ * `generateJSAndCssFilesForPreview` is private; cast to access it so the
+ * URL handling can be unit-tested without real network fetches.
+ */
+function callGenerateJSAndCssFilesForPreview(
+  engine: MarkdownEngine,
+  files: string[],
+): string {
+  return (
+    engine as unknown as {
+      generateJSAndCssFilesForPreview: (files: string[], panel: null) => string;
+    }
+  ).generateJSAndCssFilesForPreview(files, null);
+}
+
+describe('preview scripts gate (@import js and head.html)', () => {
+  track();
+
+  test('by default @import "*.js" does not load any script', async () => {
+    const tmpDir = mkdirSync({ prefix: 'xnote-scripts' });
+    fs.writeFileSync(path.join(tmpDir, 'helper.js'), 'alert("hi");');
+    fs.writeFileSync(path.join(tmpDir, 'test.md'), '# Test');
+
+    const notebook = await Notebook.init({
+      notebookPath: tmpDir,
+      config: {
+        markdownParser: 'markdown-it',
+        markdownYoBinaryPath: '',
+      },
+    });
+
+    const html = await renderPreviewTemplate(
+      notebook,
+      path.join(tmpDir, 'test.md'),
+      '@import "/helper.js"\n# Test\n',
+    );
+
+    expect(html).not.toMatch(/<script[^>]*src="[^"]*helper\.js"/);
+  });
+
+  test('opt-in loads workspace-local scripts only', async () => {
+    const tmpDir = mkdirSync({ prefix: 'xnote-scripts' });
+    const outsideDir = mkdirSync({ prefix: 'xnote-outside' });
+    fs.writeFileSync(path.join(tmpDir, 'helper.js'), 'alert("hi");');
+    fs.writeFileSync(path.join(outsideDir, 'outside.js'), 'alert("outside");');
+    fs.writeFileSync(path.join(tmpDir, 'test.md'), '# Test');
+    const outsideImportPath = path
+      .relative(tmpDir, path.join(outsideDir, 'outside.js'))
+      .split(path.sep)
+      .join('/');
+
+    const notebook = await Notebook.init({
+      notebookPath: tmpDir,
+      config: {
+        markdownParser: 'markdown-it',
+        markdownYoBinaryPath: '',
+        // @import js/css requires script execution to reach the emission
+        // gate at all (parseMD clears JSAndCssFiles otherwise)
+        enableScriptExecution: true,
+      },
+    });
+    notebook.previewScriptsEnabled = true;
+
+    const html = await renderPreviewTemplate(
+      notebook,
+      path.join(tmpDir, 'test.md'),
+      `@import "/helper.js"\n@import "/${outsideImportPath}"\n# Test\n`,
+    );
+
+    // local file inside the notebook directory is loaded
+    expect(html).toMatch(
+      /<script type="text\/javascript" src="file:\/\/[^"]*helper\.js"><\/script>/,
+    );
+    // files outside the notebook directory are not
+    expect(html).not.toMatch(/<script[^>]*src="[^"]*outside\.js"/);
+  });
+
+  test('emission gate never turns URLs into scripts (unit)', async () => {
+    const tmpDir = mkdirSync({ prefix: 'xnote-scripts' });
+    const outsideDir = mkdirSync({ prefix: 'xnote-outside' });
+    fs.writeFileSync(path.join(tmpDir, 'helper.js'), 'alert("hi");');
+    fs.writeFileSync(path.join(outsideDir, 'outside.js'), 'alert("outside");');
+    fs.writeFileSync(path.join(tmpDir, 'test.md'), '# Test');
+    const outsidePath = path.relative(
+      tmpDir,
+      path.join(outsideDir, 'outside.js'),
+    );
+
+    const notebook = await Notebook.init({
+      notebookPath: tmpDir,
+      config: {
+        markdownParser: 'markdown-it',
+        markdownYoBinaryPath: '',
+      },
+    });
+    const engine = new MarkdownEngine({
+      notebook,
+      filePath: path.join(tmpDir, 'test.md'),
+    });
+
+    const files = [
+      'https://evil.example.com/payload.js',
+      'http://evil.example.com/payload.js',
+      'file:///etc/evil.js',
+      '//evil.example.com/payload.js',
+      outsidePath,
+      'helper.js',
+    ];
+
+    // default: nothing at all is emitted
+    expect(callGenerateJSAndCssFilesForPreview(engine, files)).toBe('');
+
+    // opt-in: only the workspace-local file is emitted
+    notebook.previewScriptsEnabled = true;
+    expect(callGenerateJSAndCssFilesForPreview(engine, files)).toBe(
+      `<script type="text/javascript" src="file://${path.join(
+        tmpDir,
+        'helper.js',
+      )}"></script>`,
+    );
+  });
+
+  test('opt-in keeps only workspace-local <script src> from head.html', async () => {
+    const tmpDir = mkdirSync({ prefix: 'xnote-scripts' });
+    const configDir = path.join(tmpDir, '.crossnote');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'copy.js'), 'alert("copy");');
+
+    const headHtml = `\
+<script src="./copy.js"></script>
+<script>alert("inline");</script>
+<script src="https://evil.example.com/payload.js"></script>
+<style>
+  .custom { color: red; }
+</style>`;
+
+    fs.writeFileSync(path.join(configDir, 'head.html'), headHtml);
+    fs.writeFileSync(path.join(tmpDir, 'test.md'), '# Test');
+
+    const notebook = await Notebook.init({
+      notebookPath: tmpDir,
+      config: {
+        markdownParser: 'markdown-it',
+        markdownYoBinaryPath: '',
+      },
+    });
+    notebook.previewScriptsEnabled = true;
+
+    const html = await renderPreviewTemplate(
+      notebook,
+      path.join(tmpDir, 'test.md'),
+      '# Test\n',
+    );
+
+    // workspace-local script src is kept and rewritten to a file URL
+    expect(html).toMatch(/<script src="file:\/\/[^"]*copy\.js"><\/script>/);
+    // inline scripts and remote URLs never run (the raw head.html text
+    // may still appear inside the data-config attribute — that is inert
+    // data, not a tag)
+    expect(html).not.toContain('alert("inline")');
+    expect(html).not.toContain(
+      '<script src="https://evil.example.com/payload.js">',
+    );
+    // styles are unaffected
+    expect(html).toContain('.custom { color: red; }');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the crossnote side of the opt-in preview-scripts design for #446, restoring — in a controlled form — the custom-script capability that 0.9.31 removed (GHSA-mcwg-4j78-qwv3).

### Host-only flag: `Notebook.previewScriptsEnabled`

- New public field on `Notebook`, default `false`. **Deliberately not part of `NotebookConfig`**: config values are merged from the repository's `.crossnote/config.js` (untrusted content, sandboxed since 0.9.30), so the flag must live outside the merge path. Only the host application can set it — the VS Code extension exposes it as an application-scope setting gated on workspace trust (shd101wyy/vscode-markdown-preview-enhanced#2366).

### What the flag enables (preview only)

| channel | default | opted in |
|---|---|---|
| `head.html` inline `<script>` | stripped | stripped |
| `head.html` `<script src>` (workspace-local) | stripped | kept, rewritten to file URL |
| `head.html` `<script src="https://…">` | stripped | stripped |
| `@import "*.js"` (workspace-local) | not emitted | emitted (also requires `enableScriptExecution`) |
| `@import` URL-scheme sources (`https://`, `file://`, `//`, `data:`) | not emitted | not emitted |
| paths escaping the notebook directory (symlinks included) | — | rejected via realpath containment |
| HTML/eBook exports | stripped | stripped (unconditional) |

### Hardening beyond the flag

`generateJSAndCssFilesForPreview()` previously emitted `<script src>` for any collected path — including remote `https?://` URLs from note content (reachable when `enableScriptExecution` was on, which itself is a window-scope setting that workspace `.vscode/settings.json` can flip). URL-scheme and protocol-relative sources are now rejected outright, and resolved paths are confined to the notebook directory by `isPathInsideProjectDirectory()` (realpath-based, so a symlink inside the workspace cannot pull a script from outside).

## Test plan

- [x] New `test/preview-scripts-gate.test.ts`: default-拒绝, opt-in workspace-local only, URL-scheme/protocol-relative/traversal unit coverage, mixed head.html content
- [x] Existing `head-html-sanitize.test.ts` still green (default strip behavior unchanged)
- [x] `pnpm check` + full suite: 40 suites / 602 tests passing