### PR TITLE
build(nix): update nixpkgs to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761597516,
-        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "lastModified": 1787848966,
+        "narHash": "sha256-7gDpu5hpq0rOYnYMcOWqSzquK4HA/xU8Xf3CjUBOOJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "rev": "d57af924f160a5084293c71c2043f058bd1cdb60",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,12 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs = {
-      url = "github:NixOS/nixpkgs/nixos-25.05";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils = { url = "github:numtide/flake-utils"; };
   };
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = import nixpkgs { inherit system; };
-      in { devShell = import ./shell.nix { inherit pkgs; }; });
+      in { devShells.default = import ./shell.nix { inherit pkgs; }; });
 }


### PR DESCRIPTION
## Summary

Dev-environment only, no code impact.

- `nixpkgs`: `nixos-25.05` → `nixos-26.05` (rev `d57af924`, 2026-08-27 — same rev as the vscode-markdown-preview-enhanced repo's flake, so both dev shells share store paths).
- Dropped the self-referential `inputs.nixpkgs.follows = "nixpkgs"` override (nixpkgs has no sub-input named `nixpkgs`; it only produced an `override for a non-existent input` warning).
- `devShell` output renamed to `devShells.<system>.default` (deprecated name).

## Test plan

- [x] `nix flake update` + `nix flake check` — dev shell evaluates on 26.05 (`nodejs_22`, `pnpm`, `bash` resolve)
- [x] `pnpm check` + `pnpm test` (602 tests) green inside the updated shell