### PR TITLE
ci: install pandoc in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
           node-version-file: .tool-versions
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install pandoc
+        # Same system dependency as test.yml — the wikilink-embed and
+        # colon-fence suites spawn `pandoc`, and the runner doesn't ship
+        # it. 0.9.31's release predated those tests; without this step
+        # the release Test gate fails with `spawn pandoc ENOENT`.
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## Summary

The first release attempt after 0.9.30's test additions ([run](https://github.com/shd101wyy/crossnote/actions/runs/33264598851)) failed its Test gate with `Error: spawn pandoc ENOENT`: `release.yml` never got the "Install pandoc" step that `test.yml` has carried since #443 — the wikilink-embed and colon-fence suites spawn `pandoc`, and the bare ubuntu runner doesn't ship it. The 0.9.31 release predated those tests, so the gap stayed invisible until now.

This mirrors the exact step (and rationale) from `test.yml`. The failed dispatch aborted before any bump/publish/tag, so nothing needs cleanup.

## Test plan

- [x] Diff is the single step, identical command to test.yml
- [x] CI on this PR (which runs the full Test workflow *with* its own pandoc step) green