### PR TITLE
ci: fix shell quoting in the release changelog step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,12 @@ jobs:
         run: |
           TODAY=$(date +%F)
           # rename [Unreleased] to the new version and prepend a fresh [Unreleased] section
-          perl -0pi -e "s/^## \[Unreleased\]\n/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] - $ENV{TODAY}\n/m" CHANGELOG.md
+          # Single quotes are required: in double quotes bash expands `$ENV` (undefined)
+          # to an empty string before perl ever sees the pattern, and TODAY must be
+          # exported for perl's %ENV — both made the very first dispatch of this
+          # workflow fail its own grep check.
+          export TODAY
+          perl -0pi -e 's/^## \[Unreleased\]\n/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] - $ENV{TODAY}\n/m' CHANGELOG.md
           grep -q "## \[$NEW_VERSION\] - $TODAY" CHANGELOG.md
 
       - name: Get Changelog Entry


### PR DESCRIPTION
Second first-run bug in the #465 release workflow (first real dispatch): the perl substitution ran in double quotes, so bash ate $ENV before perl saw it and the step's own grep failed. Single quotes + exported TODAY. Substitution simulated against the real CHANGELOG.md and passes the grep. Also pre-flighted the remaining steps (master is an ancestor of develop, so the fast-forward push will succeed).