### PR TITLE
feat: inline local JS/CSS in HTML offline export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please visit https://github.com/shd101wyy/vscode-markdown-preview-enhanced/relea
 
 ## [Unreleased]
 
+### Features
+
+- **HTML (offline) export inlines local JS/CSS into a portable single file** — `htmlExport({ offline: true })` used to emit `file://` `<link>` / `<script src>` tags pointing at the host's `crossnote/dependencies/` directory (KaTeX CSS, Mermaid, WaveDrom, Vega, Reveal, Font Awesome). Those paths break when the HTML is copied to another machine. Offline HTML export now inlines those files (and rewrites CSS `url()` font references to `data:` URIs, preferring woff2). Open in Browser / Chrome PDF / Prince still use `file://` so temporary documents are not bloated with mermaid.min.js (~3.5MB). CDN export is unchanged.
+
 ## [0.9.32] - 2026-08-29
 
 ### Features

--- a/src/markdown-engine/index.ts
+++ b/src/markdown-engine/index.ts
@@ -44,6 +44,7 @@ import enhanceWithResolvedImagePaths from '../render-enhancers/resolved-image-pa
 import * as utility from '../utility';
 import { removeFileProtocol } from '../utility';
 import HeadingIdGenerator from './heading-id-generator';
+import { readOfflineCss, readOfflineJs } from './inline-offline-assets';
 import { buildMathJaxConfigScript } from './mathjax-config';
 import { sanitizeRenderedHTML } from './sanitize';
 import { HeadingData, generateSidebarToCHTML } from './toc';
@@ -98,6 +99,13 @@ export interface HTMLTemplateOption {
    * whether for offline use
    */
   offline: boolean;
+  /**
+   * Whether to inline local JS/CSS (and CSS `url()` fonts) into the
+   * HTML instead of emitting `file://` links. Used by HTML (offline)
+   * export so the file is portable; Open in Browser / PDF keep
+   * `file://` to avoid bloating temporary documents.
+   */
+  embedOfflineAssets?: boolean;
   /**
    * whether to embed local images as base64
    */
@@ -1049,6 +1057,25 @@ window["initRevealPresentation"] = async function() {
     // Build file:// URLs.  Only translate for WSL when opening in a browser.
     const fileURL = (p: string) =>
       utility.toFileURL(p, { useWSL: !!options.isForBrowser });
+    const embedAssets = !!(options.offline && options.embedOfflineAssets);
+    const depPath = (...parts: string[]) =>
+      path.resolve(utility.getCrossnoteBuildDirectory(), ...parts);
+    const offlineStyle = async (rel: string): Promise<string> => {
+      const abs = depPath(rel);
+      if (embedAssets) {
+        return readOfflineCss(abs);
+      }
+      return `<link rel="stylesheet" href="${fileURL(abs)}">`;
+    };
+    const offlineScript = async (rel: string): Promise<string> => {
+      const abs = depPath(rel);
+      if (embedAssets) {
+        return readOfflineJs(abs);
+      }
+      return `<script type="text/javascript" src="${fileURL(
+        abs,
+      )}" charset="UTF-8"></script>`;
+    };
 
     // get `id` and `class`
     const elementId = (yamlConfig['id'] as string) || '';
@@ -1097,12 +1124,7 @@ window["initRevealPresentation"] = async function() {
       }
     } else if (this.notebook.config.mathRenderingOption === 'KaTeX') {
       if (options.offline) {
-        mathStyle = `<link rel="stylesheet" href="${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            './dependencies/katex/katex.min.css',
-          ),
-        )}">`;
+        mathStyle = await offlineStyle('./dependencies/katex/katex.min.css');
       } else {
         mathStyle = `<link rel="stylesheet" href="https://${this.notebook.config.jsdelivrCdnHost}/npm/katex@0.16.47/dist/katex.min.css">`;
       }
@@ -1114,12 +1136,9 @@ window["initRevealPresentation"] = async function() {
     let fontAwesomeStyle = '';
     if (html.indexOf('<i class="fa') >= 0) {
       if (options.offline) {
-        fontAwesomeStyle = `<link rel="stylesheet" href="${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            `./dependencies/font-awesome/css/all.min.css`,
-          ),
-        )}">`;
+        fontAwesomeStyle = await offlineStyle(
+          './dependencies/font-awesome/css/all.min.css',
+        );
       } else {
         fontAwesomeStyle = `<link rel="stylesheet" href="https://${this.notebook.config.jsdelivrCdnHost}/npm/@fortawesome/fontawesome-free@6.4.2/css/all.min.css">`;
       }
@@ -1130,12 +1149,9 @@ window["initRevealPresentation"] = async function() {
     let mermaidInitScript = '';
     if (html.indexOf(' class="mermaid') >= 0) {
       if (options.offline) {
-        mermaidScript = `<script type="text/javascript" src="${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            './dependencies/mermaid/mermaid.min.js',
-          ),
-        )}" charset="UTF-8"></script>`;
+        mermaidScript = await offlineScript(
+          './dependencies/mermaid/mermaid.min.js',
+        );
       } else {
         mermaidScript = `<script src="https://${this.notebook.config.jsdelivrCdnHost}/npm/mermaid@11.17.2/dist/mermaid.min.js"></script>`;
       }
@@ -1189,24 +1205,15 @@ if (typeof(window['Reveal']) !== 'undefined') {
     let wavedromInitScript = ``;
     if (html.indexOf(' class="wavedrom') >= 0) {
       if (options.offline) {
-        wavedromScript += `<script type="text/javascript" src="${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            './dependencies/wavedrom/skins/default.js',
-          ),
-        )}" charset="UTF-8"></script>`;
-        wavedromScript += `<script type="text/javascript" src="${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            './dependencies/wavedrom/skins/narrow.js',
-          ),
-        )}" charset="UTF-8"></script>`;
-        wavedromScript += `<script type="text/javascript" src="${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            './dependencies/wavedrom/wavedrom.min.js',
-          ),
-        )}" charset="UTF-8"></script>`;
+        wavedromScript += await offlineScript(
+          './dependencies/wavedrom/skins/default.js',
+        );
+        wavedromScript += await offlineScript(
+          './dependencies/wavedrom/skins/narrow.js',
+        );
+        wavedromScript += await offlineScript(
+          './dependencies/wavedrom/wavedrom.min.js',
+        );
       } else {
         wavedromScript += `<script type="text/javascript" src="https://${this.notebook.config.jsdelivrCdnHost}/npm/wavedrom@3.3.0/skins/default.js"></script>`;
         wavedromScript += `<script type="text/javascript" src="https://${this.notebook.config.jsdelivrCdnHost}/npm/wavedrom@3.3.0/skins/narrow.js"></script>`;
@@ -1231,16 +1238,11 @@ if (typeof(window['Reveal']) !== 'undefined') {
       html.indexOf(' class="vega') >= 0 ||
       html.indexOf(' class="vega-lite') >= 0
     ) {
-      dependentLibraryMaterials.forEach(({ key, version }) => {
+      for (const { key, version } of dependentLibraryMaterials) {
         vegaScript += options.offline
-          ? `<script type="text/javascript" src="${fileURL(
-              path.resolve(
-                utility.getCrossnoteBuildDirectory(),
-                `./dependencies/${key}/${key}.min.js`,
-              ),
-            )}" charset="UTF-8"></script>`
+          ? await offlineScript(`./dependencies/${key}/${key}.min.js`)
           : `<script type="text/javascript" src="https://${this.notebook.config.jsdelivrCdnHost}/npm/${key}@${version}/build/${key}.js"></script>`;
-      });
+      }
 
       vegaInitScript += `<script>
       var vegaEls = document.querySelectorAll('.vega, .vega-lite');
@@ -1271,13 +1273,9 @@ if (typeof(window['Reveal']) !== 'undefined') {
     let presentationInitScript = '';
     if (yamlConfig['isPresentationMode']) {
       if (options.offline) {
-        presentationScript = `
-        <script src='${fileURL(
-          path.resolve(
-            utility.getCrossnoteBuildDirectory(),
-            './dependencies/reveal/js/reveal.js',
-          ),
-        )}'></script>`;
+        presentationScript = await offlineScript(
+          './dependencies/reveal/js/reveal.js',
+        );
       } else {
         presentationScript = `
         <script src='https://${this.notebook.config.jsdelivrCdnHost}/npm/reveal.js@4.6.0/dist/reveal.js'></script>`;
@@ -1421,12 +1419,9 @@ if (typeof(window['Reveal']) !== 'undefined') {
         );
 
         if (options.offline) {
-          presentationStyle += `<link rel="stylesheet" href="${fileURL(
-            path.resolve(
-              utility.getCrossnoteBuildDirectory(),
-              `./dependencies/reveal/css/theme/${theme}`,
-            ),
-          )}">`;
+          presentationStyle += await offlineStyle(
+            `./dependencies/reveal/css/theme/${theme}`,
+          );
         } else {
           presentationStyle += `<link rel="stylesheet" href="https://${this.notebook.config.jsdelivrCdnHost}/npm/reveal.js@4.6.0/dist/theme/${theme}">`;
         }
@@ -1708,6 +1703,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       isForPrince: false,
       embedLocalImages,
       offline,
+      embedOfflineAssets: offline,
       embedSVG,
     });
 

--- a/src/markdown-engine/inline-offline-assets.ts
+++ b/src/markdown-engine/inline-offline-assets.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ABSOLUTE_URL = /^(data:|https?:|file:|\/\/)/i;
+const CSS_URL = /url\(\s*(['"]?)([^'")]+)\1\s*\)(\s*format\([^)]+\))?/gi;
+const FALLBACK_FONT_EXTS = new Set(['.woff', '.ttf', '.eot', '.otf']);
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.eot': 'application/vnd.ms-fontobject',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+/**
+ * Read a JS file and wrap it as an inline `<script>` tag for a
+ * self-contained HTML export. A literal `</script>` in the source is
+ * escaped so it cannot close the wrapping tag.
+ */
+export async function readOfflineJs(absPath: string): Promise<string> {
+  const js = await fs.promises.readFile(absPath, 'utf8');
+  const escaped = js.replace(/<\/script/gi, '<\\/script');
+  return `<script type="text/javascript">\n${escaped}\n</script>`;
+}
+
+/**
+ * Read a CSS file, rewrite relative `url(...)` references to data URIs,
+ * and wrap the result as an inline `<style>` tag.
+ *
+ * Absolute `data:` / `http(s):` / `file:` URLs are left as-is. Missing
+ * files are dropped rather than left as broken relative paths. When a
+ * `@font-face` lists woff2 + woff/ttf fallbacks, only the woff2 file is
+ * embedded.
+ */
+export async function readOfflineCss(absPath: string): Promise<string> {
+  const css = await fs.promises.readFile(absPath, 'utf8');
+  const rewritten = rewriteCssUrls(css, path.dirname(absPath));
+  return `<style>\n${rewritten}\n</style>`;
+}
+
+function rewriteCssUrls(css: string, cssDir: string): string {
+  const rewritten = css.replace(
+    CSS_URL,
+    (whole, _quote: string, rawUrl: string, formatPart = '') => {
+      const url = rawUrl.trim();
+      if (ABSOLUTE_URL.test(url)) {
+        return whole;
+      }
+
+      const resolved = path.resolve(cssDir, url);
+      const ext = path.extname(resolved).toLowerCase();
+
+      if (FALLBACK_FONT_EXTS.has(ext)) {
+        const woff2 = resolved.slice(0, -ext.length) + '.woff2';
+        if (fs.existsSync(woff2)) {
+          return '';
+        }
+      }
+
+      if (!fs.existsSync(resolved)) {
+        return '';
+      }
+
+      const mime = MIME_BY_EXT[ext] ?? 'application/octet-stream';
+      const b64 = fs.readFileSync(resolved).toString('base64');
+      return `url("data:${mime};base64,${b64}")${formatPart}`;
+    },
+  );
+
+  return rewritten
+    .replace(/,\s*,+/g, ',')
+    .replace(/:\s*,/g, ':')
+    .replace(/,\s*(?=[;}])/g, '');
+}

--- a/test/html-export-offline-embed.test.ts
+++ b/test/html-export-offline-embed.test.ts
@@ -1,0 +1,155 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { mkdirSync, track } from '../src/lib/temp';
+import { MarkdownEngine } from '../src/markdown-engine';
+import { Notebook } from '../src/notebook';
+import {
+  getCrossnoteBuildDirectory,
+  setCrossnoteBuildDirectory,
+} from '../src/utility';
+
+jest.mock('less', () => ({
+  render: (
+    _input: string,
+    _options: unknown,
+    callback: (error: unknown, output: { css: string } | undefined) => void,
+  ) => {
+    callback(null, { css: '' });
+  },
+}));
+
+function writeFakeBuildDirectory(root: string) {
+  const previewThemeDir = path.join(root, 'styles', 'preview_theme');
+  const prismThemeDir = path.join(root, 'styles', 'prism_theme');
+  const katexFontsDir = path.join(root, 'dependencies', 'katex', 'fonts');
+  const mermaidDir = path.join(root, 'dependencies', 'mermaid');
+  fs.mkdirSync(previewThemeDir, { recursive: true });
+  fs.mkdirSync(prismThemeDir, { recursive: true });
+  fs.mkdirSync(katexFontsDir, { recursive: true });
+  fs.mkdirSync(mermaidDir, { recursive: true });
+
+  const files: Array<[string, string]> = [
+    [
+      path.join(previewThemeDir, 'github-light.css'),
+      '/* preview:github-light */',
+    ],
+    [
+      path.join(previewThemeDir, 'github-dark.css'),
+      '/* preview:github-dark */',
+    ],
+    [path.join(prismThemeDir, 'github.css'), '/* prism:github */'],
+    [path.join(prismThemeDir, 'github-dark.css'), '/* prism:github-dark */'],
+    [path.join(root, 'styles', 'style-template.css'), '/* style-template */'],
+    [
+      path.join(root, 'dependencies', 'katex', 'katex.min.css'),
+      '@font-face{font-family:KaTeX_Main;src:url(fonts/KaTeX_Main-Regular.woff2) format("woff2"),url(fonts/KaTeX_Main-Regular.woff) format("woff")}.katex{font-family:KaTeX_Main}',
+    ],
+    [path.join(katexFontsDir, 'KaTeX_Main-Regular.woff2'), 'WOFF2FONT'],
+    [path.join(katexFontsDir, 'KaTeX_Main-Regular.woff'), 'WOFF1FONT'],
+    [
+      path.join(mermaidDir, 'mermaid.min.js'),
+      'window.MERMAID_OFFLINE_MARKER = true;',
+    ],
+  ];
+  files.forEach(([file, content]) => fs.writeFileSync(file, content));
+}
+
+describe('HTML export offline asset embedding', () => {
+  track();
+
+  const originalBuildDirectory = getCrossnoteBuildDirectory();
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdirSync({ prefix: 'xnote-html-offline-embed' });
+    writeFakeBuildDirectory(tmpDir);
+    setCrossnoteBuildDirectory(tmpDir);
+  });
+
+  afterAll(() => {
+    setCrossnoteBuildDirectory(originalBuildDirectory);
+  });
+
+  async function renderExportTemplate(
+    bodyHtml: string,
+    options: {
+      offline: boolean;
+      embedOfflineAssets?: boolean;
+    },
+  ): Promise<string> {
+    const notebook = await Notebook.init({
+      notebookPath: tmpDir,
+      config: {
+        markdownParser: 'markdown-it',
+        markdownYoBinaryPath: '',
+        mathRenderingOption: 'KaTeX',
+      },
+    });
+    const engine = new MarkdownEngine({
+      notebook,
+      filePath: path.join(tmpDir, 'test.md'),
+    });
+    return engine.generateHTMLTemplateForExport(
+      bodyHtml,
+      {},
+      {
+        isForPrint: false,
+        isForPrince: false,
+        offline: options.offline,
+        embedLocalImages: false,
+        embedOfflineAssets: options.embedOfflineAssets,
+      },
+    );
+  }
+
+  const mermaidBody = '<div class="mermaid">graph TD; A-->B;</div>';
+
+  test('offline+embed inlines katex css and mermaid js without file:// deps', async () => {
+    const html = await renderExportTemplate(mermaidBody, {
+      offline: true,
+      embedOfflineAssets: true,
+    });
+
+    expect(html).not.toMatch(/file:\/\//);
+    expect(html).not.toMatch(
+      /<link rel="stylesheet" href="[^"]*katex\.min\.css"/,
+    );
+    expect(html).not.toMatch(/<script[^>]*src="[^"]*mermaid\.min\.js"/);
+    expect(html).toContain('window.MERMAID_OFFLINE_MARKER = true;');
+    expect(html).toContain('.katex{font-family:KaTeX_Main}');
+    expect(html).toContain(
+      'data:font/woff2;base64,' + Buffer.from('WOFF2FONT').toString('base64'),
+    );
+    expect(html).not.toContain(Buffer.from('WOFF1FONT').toString('base64'));
+  });
+
+  test('offline without embed still uses file:// (Open in Browser / PDF)', async () => {
+    const html = await renderExportTemplate(mermaidBody, {
+      offline: true,
+    });
+
+    expect(html).toMatch(/file:\/\/.*katex\.min\.css/);
+    expect(html).toMatch(/file:\/\/.*mermaid\.min\.js/);
+    expect(html).not.toContain('window.MERMAID_OFFLINE_MARKER = true;');
+  });
+
+  test('cdn export still uses https urls', async () => {
+    const html = await renderExportTemplate(mermaidBody, {
+      offline: false,
+    });
+
+    expect(html).toMatch(/https:\/\/.*katex@/);
+    expect(html).toMatch(/https:\/\/.*mermaid@/);
+    expect(html).not.toContain('window.MERMAID_OFFLINE_MARKER = true;');
+  });
+
+  test('plain paragraph does not inline mermaid.js', async () => {
+    const html = await renderExportTemplate('<p>hello</p>', {
+      offline: true,
+      embedOfflineAssets: true,
+    });
+
+    expect(html).not.toContain('window.MERMAID_OFFLINE_MARKER = true;');
+    expect(html).toContain('.katex{font-family:KaTeX_Main}');
+  });
+});

--- a/test/inline-offline-assets.test.ts
+++ b/test/inline-offline-assets.test.ts
@@ -1,0 +1,140 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { mkdirSync, track } from '../src/lib/temp';
+import {
+  readOfflineCss,
+  readOfflineJs,
+} from '../src/markdown-engine/inline-offline-assets';
+
+describe('inline-offline-assets', () => {
+  track();
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdirSync({ prefix: 'xnote-inline-assets' });
+  });
+
+  describe('readOfflineJs', () => {
+    test('wraps the file contents in an inline script tag', async () => {
+      const jsPath = path.join(tmpDir, 'lib.js');
+      fs.writeFileSync(jsPath, 'window.MERMAID_MARKER = true;');
+
+      const html = await readOfflineJs(jsPath);
+
+      expect(html).toContain('<script type="text/javascript">');
+      expect(html).toContain('window.MERMAID_MARKER = true;');
+      expect(html).toContain('</script>');
+      expect(html).not.toContain('src=');
+    });
+
+    test('escapes a closing script tag inside the source', async () => {
+      const jsPath = path.join(tmpDir, 'evil.js');
+      fs.writeFileSync(jsPath, 'var s = "</script><p>xss</p>";');
+
+      const html = await readOfflineJs(jsPath);
+
+      expect(html).toContain('<\\/script');
+      expect(html).not.toMatch(/<\/script><p>xss<\/p>/);
+    });
+  });
+
+  describe('readOfflineCss', () => {
+    test('wraps the file contents in an inline style tag', async () => {
+      const cssPath = path.join(tmpDir, 'plain.css');
+      fs.writeFileSync(cssPath, '.katex { font-size: 1.21em; }');
+
+      const html = await readOfflineCss(cssPath);
+
+      expect(html).toContain('<style>');
+      expect(html).toContain('.katex { font-size: 1.21em; }');
+      expect(html).toContain('</style>');
+      expect(html).not.toContain('<link');
+    });
+
+    test('rewrites a relative font url to a data URI', async () => {
+      const fontsDir = path.join(tmpDir, 'fonts');
+      fs.mkdirSync(fontsDir);
+      const fontPath = path.join(fontsDir, 'KaTeX_Main-Regular.woff2');
+      fs.writeFileSync(fontPath, Buffer.from('WOFF2FONT'));
+      const cssPath = path.join(tmpDir, 'katex.css');
+      fs.writeFileSync(
+        cssPath,
+        '@font-face{src:url(fonts/KaTeX_Main-Regular.woff2) format("woff2")}',
+      );
+
+      const html = await readOfflineCss(cssPath);
+
+      const expected =
+        'data:font/woff2;base64,' + Buffer.from('WOFF2FONT').toString('base64');
+      expect(html).toContain(`url("${expected}")`);
+      expect(html).toContain('format("woff2")');
+      expect(html).not.toContain('fonts/KaTeX_Main-Regular.woff2');
+    });
+
+    test('keeps only woff2 when woff and ttf siblings exist', async () => {
+      const fontsDir = path.join(tmpDir, 'fonts');
+      fs.mkdirSync(fontsDir);
+      fs.writeFileSync(
+        path.join(fontsDir, 'KaTeX_AMS-Regular.woff2'),
+        Buffer.from('W2'),
+      );
+      fs.writeFileSync(
+        path.join(fontsDir, 'KaTeX_AMS-Regular.woff'),
+        Buffer.from('W1'),
+      );
+      fs.writeFileSync(
+        path.join(fontsDir, 'KaTeX_AMS-Regular.ttf'),
+        Buffer.from('TT'),
+      );
+      const cssPath = path.join(tmpDir, 'katex.css');
+      fs.writeFileSync(
+        cssPath,
+        '@font-face{src:url(fonts/KaTeX_AMS-Regular.woff2) format("woff2"),url(fonts/KaTeX_AMS-Regular.woff) format("woff"),url(fonts/KaTeX_AMS-Regular.ttf) format("truetype")}',
+      );
+
+      const html = await readOfflineCss(cssPath);
+
+      expect(html).toContain(
+        'data:font/woff2;base64,' + Buffer.from('W2').toString('base64'),
+      );
+      expect(html).not.toContain(Buffer.from('W1').toString('base64'));
+      expect(html).not.toContain(Buffer.from('TT').toString('base64'));
+      expect(html).not.toContain('format("woff")');
+      expect(html).not.toContain('format("truetype")');
+    });
+
+    test('leaves data, http, https and file urls untouched', async () => {
+      const cssPath = path.join(tmpDir, 'external.css');
+      fs.writeFileSync(
+        cssPath,
+        [
+          'a{background:url(data:image/gif;base64,AAAA)}',
+          'b{background:url(https://cdn.example/x.png)}',
+          'c{background:url(http://cdn.example/y.png)}',
+          'd{background:url(file:///tmp/z.png)}',
+        ].join(''),
+      );
+
+      const html = await readOfflineCss(cssPath);
+
+      expect(html).toContain('url(data:image/gif;base64,AAAA)');
+      expect(html).toContain('url(https://cdn.example/x.png)');
+      expect(html).toContain('url(http://cdn.example/y.png)');
+      expect(html).toContain('url(file:///tmp/z.png)');
+    });
+
+    test('drops a relative url whose file is missing', async () => {
+      const cssPath = path.join(tmpDir, 'missing.css');
+      fs.writeFileSync(
+        cssPath,
+        '.x{background:url(fonts/does-not-exist.woff2) format("woff2")}',
+      );
+
+      const html = await readOfflineCss(cssPath);
+
+      expect(html).not.toContain('does-not-exist');
+      expect(html).toContain('.x{background:');
+    });
+  });
+});


### PR DESCRIPTION
Offline HTML used file:// links into the host's dependencies directory, so the file broke when copied to another machine. Inline those assets (and woff2 font data URIs) for htmlExport while leaving Open in Browser / PDF on file://.