### PR TITLE
fix: contain the note-index walk to the notebook root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ test.js
 test.mjs
 .direnv
 .codegraph
+.mimosa
+.video_agent
 tsconfig.tsbuildinfo
 pnpm-debug.log
 .mume

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,5 @@ src/prism/prism.js
 styles/*.css
 test/markdown/test-files/**
 pnpm-lock.yaml
+.mimosa/**
+.video_agent/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please visit https://github.com/shd101wyy/vscode-markdown-preview-enhanced/relea
 
 ## [Unreleased]
 
+### Security
+
+- **Contain the note-index walk to the notebook root** — the walk behind `refreshNotes` / `refreshNotesIncremental` (wikilink resolution, backlinks, tags, graph view) could scan far beyond the workspace: a notebook rooted at a filesystem root (`/`, a Windows drive root — e.g. VS Code opened on `/`, a standalone file directly under it, or an untitled document whose fallback root is the `/.` spelling of `/`) recursively stat'ed and read files across the whole machine, and a symbolic link inside the workspace let the walk escape it entirely (followed links also risk cycles). Filesystem-root notebooks are now refused by all refresh entry points (a one-time warning explains that indexing is skipped), and the walk never follows symbolic links (Obsidian-style containment: link entries are not indexed). Walk-time `readdir`/`stat` failures such as `EACCES`/`EPERM` are also no longer `console.error`'d per directory — they are the normal cost of walking restricted trees, and logging each one is what made the scan visible as 1000+ error entries ([vscode-mpe#2376](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2376) reported by @prawnsalad). `wrapNodeFSAsApi().stat` now reports `isSymbolicLink()` truthfully (lstat first, follow for metadata), matching the VS Code host adapter.
+
 ## [0.9.32] - 2026-08-29
 
 ### Features

--- a/src/notebook/config-helper.ts
+++ b/src/notebook/config-helper.ts
@@ -257,6 +257,26 @@ export function wrapNodeFSAsApi(): FileSystemApi {
       return fs.existsSync(_path);
     },
     stat: async (_path: string) => {
+      // lstat first so symlink entries keep reporting
+      // `isSymbolicLink() === true`; the walk uses that to refuse
+      // following links out of the notebook root.  Metadata (size,
+      // mtimes, file/dir type) still comes from the followed target.
+      const lstats = await fsPromises.lstat(_path).catch(() => undefined);
+      if (lstats?.isSymbolicLink()) {
+        const stats = await fsPromises.stat(_path);
+        return {
+          mtimeMs: stats.mtimeMs,
+          ctimeMs: stats.ctimeMs,
+          size: stats.size,
+          isFile: () => stats.isFile(),
+          isDirectory: () => stats.isDirectory(),
+          isSymbolicLink: () => true,
+        };
+      }
+      if (lstats) {
+        return lstats;
+      }
+      // lstat failed (ENOENT etc.) — let stat throw the real error.
       return await fsPromises.stat(_path);
     },
     readdir: async (_path: string) => {

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -129,6 +129,11 @@ export class Notebook {
   public notes: Notes = {};
   public hasLoadedNotes: boolean = false;
   /**
+   * Whether `skipIndexingIfFilesystemRoot` has already warned for this
+   * notebook, so the refusal is logged once per instance.
+   */
+  private filesystemRootWarned: boolean = false;
+  /**
    * The notebook-relative path of the note currently being rendered.
    * Set by MarkdownEngine.parseMD() before calling renderMarkdown().
    * Used by the wikilink renderer to call resolveWikilink() with the
@@ -985,6 +990,8 @@ export class Notebook {
   }: RefreshNotesIfNotLoaded): Promise<Notes> {
     await this.refreshNotesIfNotLoadedMutex.runExclusive(async () => {
       if (!this.hasLoadedNotes) {
+        // A filesystem-root notebook is refused inside refreshNotes;
+        // marking it loaded either way keeps callers from retrying.
         await this.refreshNotes({
           dir,
           includeSubdirectories,
@@ -994,6 +1001,31 @@ export class Notebook {
       }
     });
     return this.notes;
+  }
+
+  /**
+   * True when the notebook is rooted at a filesystem root (`/` on
+   * macOS/Linux, `C:\` on Windows) rather than an actual folder —
+   * including dot-path spellings of it such as `/.`, which hosts can
+   * produce for untitled documents (they resolve to `/`).  Indexing
+   * such a "notebook" would recursively stat and read files across
+   * the whole machine (vscode-markdown-preview-enhanced#2376), so
+   * every refresh entry point refuses to walk it.  Warns once.
+   */
+  private skipIndexingIfFilesystemRoot(): boolean {
+    const resolved = path.resolve(this.notebookPath.fsPath);
+    if (path.parse(resolved).root !== resolved) {
+      return false;
+    }
+    if (!this.filesystemRootWarned) {
+      this.filesystemRootWarned = true;
+      console.warn(
+        `Crossnote: notebook root "${this.notebookPath.fsPath}" is a filesystem root; ` +
+          'skipping note indexing (wikilinks/backlinks/graph will find nothing). ' +
+          'Open a specific folder as the notebook root instead.',
+      );
+    }
+    return true;
   }
 
   /** Try to load a .gitignore file from the given absolute directory path. */
@@ -1013,6 +1045,9 @@ export class Notebook {
 
   public async refreshNotes(args: RefreshNotesArgs): Promise<Notes> {
     return this.refreshNotesMutex.runExclusive(async () => {
+      if (this.skipIndexingIfFilesystemRoot()) {
+        return this.notes;
+      }
       const { refreshRelations = true } = args;
       if (refreshRelations) {
         this.notes = {};
@@ -1047,6 +1082,9 @@ export class Notebook {
    */
   public async refreshNotesIncremental(args: RefreshNotesArgs): Promise<Notes> {
     return this.refreshNotesMutex.runExclusive(async () => {
+      if (this.skipIndexingIfFilesystemRoot()) {
+        return this.notes;
+      }
       const { dir = './', includeSubdirectories = false } = args;
       const onDisk = new Map<string, number>();
       await this._collectOnDiskMtimes(dir, includeSubdirectories, [], onDisk);
@@ -1123,6 +1161,10 @@ export class Notebook {
    * a .gitignore in the current stack.  Directories are descended
    * into iff `includeSubdirectories` is true.
    *
+   * Symbolic links are never followed: a link can point outside the
+   * notebook root (escaping the workspace entirely) or form a cycle,
+   * so entries whose stat reports `isSymbolicLink()` are skipped.
+   *
    * Both `_refreshNotesInternal` (full rebuild) and
    * `_collectOnDiskMtimes` (incremental refresh) drive their work
    * through this helper so the gitignore semantics are defined in
@@ -1178,8 +1220,9 @@ export class Notebook {
     let files: string[];
     try {
       files = await this.fs.readdir(dirAbsPath);
-    } catch (error) {
-      console.error(error);
+    } catch {
+      // Unreadable directory (EACCES/EPERM/...).  A walk of a large or
+      // restricted tree hits these routinely — expected, not an error.
       return;
     }
 
@@ -1203,8 +1246,17 @@ export class Notebook {
       let stats: FileSystemStats;
       try {
         stats = await this.fs.stat(absFilePath);
-      } catch (error) {
-        console.error(error);
+      } catch {
+        // Unstatable entry — same reasoning as the readdir catch above.
+        continue;
+      }
+
+      // Symbolic links can point outside the notebook root (or form
+      // cycles), which would let the index walk escape the workspace
+      // and stat/read files it has no business touching (#2376).
+      // Links are therefore never followed by the walk; the same
+      // Obsidian-style containment the rest of the index assumes.
+      if (stats.isSymbolicLink()) {
         continue;
       }
 

--- a/test/notebook-walk-containment.test.ts
+++ b/test/notebook-walk-containment.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Containment guarantees for the note-index walk (#2376 in
+ * vscode-markdown-preview-enhanced):
+ *
+ * 1. A notebook rooted at a filesystem root (`/`) must never walk —
+ *    indexing it would stat/read files across the whole machine.
+ * 2. The walk must not follow symbolic links out of the notebook root
+ *    (a symlinked directory previously let the walk escape the
+ *    workspace entirely).
+ */
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { FileSystemApi, Notebook } from '../src/notebook';
+
+/**
+ * An fs mock that records every readdir/stat call and fails the test
+ * if any of them happen.  `Notebook.init` only touches `exists` (for
+ * `/.crossnote`), so anything beyond that means the guard leaked.
+ */
+function fsThatMustNotBeWalked(): FileSystemApi & {
+  accessed: string[];
+} {
+  const accessed: string[] = [];
+  const boom = (op: string, p: string) => {
+    accessed.push(`${op}:${p}`);
+    throw new Error(`unexpected fs.${op}("${p}") — the walk must not run`);
+  };
+  return {
+    accessed,
+    readFile: async (p) => boom('readFile', p),
+    writeFile: async (p) => boom('writeFile', p),
+    mkdir: async (p) => boom('mkdir', p),
+    exists: async () => false,
+    stat: async (p) => boom('stat', p),
+    readdir: async (p) => boom('readdir', p),
+    unlink: async (p) => boom('unlink', p),
+  };
+}
+
+describe('notebook walk containment', () => {
+  describe('filesystem-root notebook', () => {
+    it('refreshNotes does not walk and returns no notes', async () => {
+      const mock = fsThatMustNotBeWalked();
+      const nb = await Notebook.init({
+        notebookPath: 'file:///',
+        fs: mock,
+        config: { markdownParser: 'markdown-it' },
+      });
+
+      const notes = await nb.refreshNotes({
+        dir: '.',
+        includeSubdirectories: true,
+      });
+
+      expect(Object.keys(notes)).toHaveLength(0);
+      expect(nb.hasLoadedNotes).toBe(false);
+      expect(mock.accessed).toHaveLength(0);
+    });
+
+    it('refreshNotesIfNotLoaded and refreshNotesIncremental do not walk', async () => {
+      const mock = fsThatMustNotBeWalked();
+      const nb = await Notebook.init({
+        notebookPath: 'file:///',
+        fs: mock,
+        config: { markdownParser: 'markdown-it' },
+      });
+
+      await nb.refreshNotesIfNotLoaded({
+        dir: '.',
+        includeSubdirectories: true,
+      });
+      await nb.refreshNotesIncremental({
+        dir: '.',
+        includeSubdirectories: true,
+      });
+
+      expect(mock.accessed).toHaveLength(0);
+    });
+
+    it('a dot-path spelling of the root (file:///., the untitled-document fallback) does not walk', async () => {
+      const mock = fsThatMustNotBeWalked();
+      const nb = await Notebook.init({
+        notebookPath: 'file:///.',
+        fs: mock,
+        config: { markdownParser: 'markdown-it' },
+      });
+
+      const notes = await nb.refreshNotes({
+        dir: '.',
+        includeSubdirectories: true,
+      });
+
+      expect(Object.keys(notes)).toHaveLength(0);
+      expect(mock.accessed).toHaveLength(0);
+    });
+  });
+
+  // Symlink creation needs elevated privileges on Windows.
+  (process.platform === 'win32' ? describe.skip : describe)(
+    'symbolic links',
+    () => {
+      let notebookPath: string;
+      let outsidePath: string;
+
+      beforeEach(async () => {
+        const base = await fs.mkdtemp(
+          path.join(os.tmpdir(), 'crossnote-containment-'),
+        );
+        notebookPath = path.join(base, 'notebook');
+        outsidePath = path.join(base, 'outside');
+        await fs.mkdir(notebookPath);
+        await fs.mkdir(outsidePath);
+        await fs.mkdir(path.join(outsidePath, 'deep'));
+        await fs.writeFile(path.join(outsidePath, 'secret.md'), 'outside file');
+        await fs.writeFile(
+          path.join(outsidePath, 'deep', 'secret.md'),
+          'outside nested file',
+        );
+        await fs.writeFile(path.join(notebookPath, 'inside.md'), 'inside');
+      });
+
+      afterEach(async () => {
+        await fs.rm(path.dirname(notebookPath), {
+          recursive: true,
+          force: true,
+        });
+      });
+
+      async function loaded(): Promise<Notebook> {
+        const nb = await Notebook.init({
+          notebookPath,
+          config: { markdownParser: 'markdown-it' },
+        });
+        await nb.refreshNotes({ dir: '.', includeSubdirectories: true });
+        return nb;
+      }
+
+      it('does not index through a symlinked directory', async () => {
+        await fs.symlink(outsidePath, path.join(notebookPath, 'escape'), 'dir');
+        const nb = await loaded();
+
+        expect(Object.keys(nb.notes)).toEqual(['inside.md']);
+      });
+
+      it('does not index a symlinked file', async () => {
+        await fs.symlink(
+          path.join(outsidePath, 'secret.md'),
+          path.join(notebookPath, 'link.md'),
+          'file',
+        );
+        const nb = await loaded();
+
+        expect(Object.keys(nb.notes)).toEqual(['inside.md']);
+      });
+
+      it('incremental refresh also skips symlinks', async () => {
+        await fs.symlink(outsidePath, path.join(notebookPath, 'escape'), 'dir');
+        const nb = await loaded();
+        await nb.refreshNotesIncremental({
+          dir: '.',
+          includeSubdirectories: true,
+        });
+
+        expect(Object.keys(nb.notes)).toEqual(['inside.md']);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What

The recursive directory walk that builds the note index (wikilink resolution, backlinks, tags, graph view) could scan far beyond the workspace:

- **Filesystem-root notebooks** — a notebook rooted at `/` (a Windows drive root, or dot-path spellings like `/.`, which hosts produce for untitled documents since `path.dirname('Untitled-1') === '.'` → `URI.file('.')` → fsPath `/.`) recursively stat'ed and **read every markdown file on the machine**. Reported in [vscode-mpe#2376](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2376): 1221 `EACCES`/`EPERM` error entries across `/Users`, `/Library`, `/System`, `/private/var`, `/Volumes`, …
- **Symlink escape** — the walk used symlink-following `stat` with no containment check, so a symbolic link inside the workspace (or a cycle) let the recursion leave the workspace entirely.

## Fix

- `refreshNotes`, `refreshNotesIncremental` and `refreshNotesIfNotLoaded` refuse to walk a filesystem-root notebook (guard normalizes with `path.resolve`, so `/.`/`/..` spellings are caught) and warn once.
- `_walkNotebookDir` never follows symbolic links — Obsidian-style containment; link entries are simply not indexed (documented behavior change).
- Walk-time `readdir`/`stat` failures (`EACCES`/`EPERM`) are no longer `console.error`'d per directory — they are the normal cost of walking restricted trees, and logging each one is what made the #2376 scan visible as 1000+ error entries.
- `wrapNodeFSAsApi().stat` now reports `isSymbolicLink()` truthfully (lstat first, follow for metadata), matching the VS Code host adapter.

## Tests

New `test/notebook-walk-containment.test.ts`: filesystem-root notebooks (`file:///` and the `file:///.` untitled fallback) must not touch the fs at all (mock fails the test on any access), and symlinked dirs/files are not indexed by either the full or the incremental refresh. Full suite: 627 passing.

Also ignores local tool-state dirs (`.mimosa`, `.video_agent`) in git and prettier.

Fixes vscode-markdown-preview-enhanced#2376 (together with the companion extension PR)