### PR TITLE
feat: add 'vertical table' front matter rendering option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please visit https://github.com/shd101wyy/vscode-markdown-preview-enhanced/relea
 ### Features
 
 - **HTML (offline) export inlines local JS/CSS into a portable single file** — `htmlExport({ offline: true })` used to emit `file://` `<link>` / `<script src>` tags pointing at the host's `crossnote/dependencies/` directory (KaTeX CSS, Mermaid, WaveDrom, Vega, Reveal, Font Awesome). Those paths break when the HTML is copied to another machine. Offline HTML export now inlines those files (and rewrites CSS `url()` font references to `data:` URIs, preferring woff2). Open in Browser / Chrome PDF / Prince still use `file://` so temporary documents are not bloated with mermaid.min.js (~3.5MB). CDN export is unchanged.
+- **`frontMatterRenderingOption: 'vertical table'`** — a second table layout for front matter: instead of one column per key (which overflows the preview pane when there are many keys or long values), the table renders one key/value pair per row, matching the layout VS Code's built-in preview uses. Nested objects recurse vertically; array values stay a single row of cells. The existing `'table'` (one column per key), `'none'` and `'code'`/`'code block'` options are unchanged ([vscode-mpe#2371](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2371) reported by @JaeyeongYang).
 
 ### Security
 

--- a/src/markdown-engine/index.ts
+++ b/src/markdown-engine/index.ts
@@ -2644,22 +2644,45 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     this.graphsCache = {};
   }
 
-  private frontMatterToTable(arg: unknown) {
+  /**
+   * Render a parsed front-matter value as HTML table markup.
+   *
+   * `vertical` selects the one-key-per-row layout (`<th>` key cell +
+   * `<td>` value cell per row) instead of the default one-column-per-key
+   * layout, which overflows the preview pane when there are many keys
+   * or long values.
+   */
+  private frontMatterToTable(arg: unknown, vertical: boolean = false) {
     if (arg instanceof Array) {
       let tbody = '<tbody><tr>';
       arg.forEach(
-        (item) => (tbody += `<td>${this.frontMatterToTable(item)}</td>`),
+        (item) =>
+          (tbody += `<td>${this.frontMatterToTable(item, vertical)}</td>`),
       );
       tbody += '</tr></tbody>';
       return `<table>${tbody}</table>`;
     } else if (typeof arg === 'object') {
+      if (vertical) {
+        let tbody = '<tbody>';
+        for (const key in arg) {
+          // eslint-disable-next-line no-prototype-builtins
+          if (arg.hasOwnProperty(key)) {
+            tbody += `<tr><th>${escape(key)}</th><td>${this.frontMatterToTable(
+              (arg as Record<string, unknown>)[key],
+              vertical,
+            )}</td></tr>`;
+          }
+        }
+        tbody += '</tbody>';
+        return `<table>${tbody}</table>`;
+      }
       let thead = '<thead><tr>';
       let tbody = '<tbody><tr>';
       for (const key in arg) {
         // eslint-disable-next-line no-prototype-builtins
         if (arg.hasOwnProperty(key)) {
           thead += `<th>${escape(key)}</th>`;
-          tbody += `<td>${this.frontMatterToTable((arg as Record<string, unknown>)[key])}</td>`;
+          tbody += `<td>${this.frontMatterToTable((arg as Record<string, unknown>)[key], vertical)}</td>`;
         }
       }
       thead += '</tr></thead>';
@@ -2702,13 +2725,19 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         // hide
         return { content: '', table: '', data };
       } else if (
-        (this.notebook.config.frontMatterRenderingOption ?? '')[0] === 't'
+        ['t', 'v'].includes(
+          (this.notebook.config.frontMatterRenderingOption ?? '')[0],
+        )
       ) {
-        // table
-        // to table
+        // 'table' (keys as columns) or 'vertical table' (one key/value
+        // pair per row, which keeps the table inside the preview pane
+        // when there are many keys or long values —
+        // vscode-markdown-preview-enhanced#2371)
+        const vertical =
+          (this.notebook.config.frontMatterRenderingOption ?? '')[0] === 'v';
         let table;
         if (typeof data === 'object') {
-          table = this.frontMatterToTable(data);
+          table = this.frontMatterToTable(data, vertical);
         } else {
           table =
             '<pre class="language-text"><code>Failed to parse YAML.</code></pre>';

--- a/src/notebook/types.ts
+++ b/src/notebook/types.ts
@@ -113,7 +113,19 @@ export type RevealJsTheme =
 
 export type MermaidTheme = 'default' | 'forest' | 'dark' | 'neutral' | 'null';
 
-export type FrontMatterRenderingOption = 'none' | 'table' | 'code';
+/**
+ * How YAML front matter is rendered.  `'table'` lays keys out as
+ * columns (one header row); `'vertical table'` lays out one key/value
+ * pair per row, which stays readable when there are many keys or long
+ * values.  `'code'`/`'code block'` are the same option — hosts pick
+ * the spelling shown in their settings UI.
+ */
+export type FrontMatterRenderingOption =
+  | 'none'
+  | 'table'
+  | 'vertical table'
+  | 'code'
+  | 'code block';
 
 export type WikiLinkTargetFileNameChangeCase =
   | 'none'

--- a/test/front-matter-table.test.ts
+++ b/test/front-matter-table.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for `frontMatterRenderingOption` table layouts.
+ *
+ * 'vertical table' renders one key/value pair per row so the table
+ * stays inside the preview pane when there are many keys or long
+ * values (vscode-markdown-preview-enhanced#2371); 'table' keeps the
+ * historical one-column-per-key layout.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FrontMatterRenderingOption, Notebook } from '../src/notebook/index';
+
+describe('front matter rendering', () => {
+  let tmp: string;
+
+  const parse = async (
+    option: FrontMatterRenderingOption,
+    frontMatter: string,
+  ) => {
+    const notebook = await Notebook.init({
+      notebookPath: tmp,
+      config: {
+        markdownParser: 'markdown-it',
+        frontMatterRenderingOption: option,
+      },
+    });
+    const filePath = path.join(tmp, 'note.md');
+    fs.writeFileSync(filePath, frontMatter + '\nBody text.\n');
+    const engine = notebook.getNoteMarkdownEngine(filePath);
+    const { html } = await engine.parseMD(frontMatter + '\nBody text.\n', {
+      useRelativeFilePath: false,
+      isForPreview: true,
+      hideFrontMatter: false,
+    });
+    return html;
+  };
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'front-matter-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const frontMatter = [
+    '---',
+    'title: Hello World',
+    'num: 42',
+    'tags:',
+    '  - a',
+    '  - b',
+    'author:',
+    '  name: Jaeyeong',
+    '---',
+    '',
+  ].join('\n');
+
+  it("'vertical table' renders one key/value pair per row", async () => {
+    const html = await parse('vertical table', frontMatter);
+
+    expect(html).toContain('<tr><th>title</th><td>Hello World</td></tr>');
+    expect(html).toContain('<tr><th>num</th><td>42</td></tr>');
+    // Array values stay a single row of cells.
+    expect(html).toContain(
+      '<tr><th>tags</th><td><table><tbody><tr><td>a</td><td>b</td></tr></tbody></table></td></tr>',
+    );
+    // Nested objects recurse vertically.
+    expect(html).toContain(
+      '<tr><th>author</th><td><table><tbody><tr><th>name</th><td>Jaeyeong</td></tr></tbody></table></td></tr>',
+    );
+    expect(html).not.toContain('<thead>');
+    // The body is still rendered after the table.
+    expect(html).toContain('Body text.');
+  });
+
+  it("'table' keeps the one-column-per-key layout", async () => {
+    const html = await parse('table', frontMatter);
+
+    expect(html).toContain(
+      '<table><thead><tr><th>title</th><th>num</th><th>tags</th><th>author</th></tr></thead>',
+    );
+    expect(html).toContain('<td>Hello World</td>');
+    // Nested objects recurse horizontally.
+    expect(html).toContain(
+      '<td><table><thead><tr><th>name</th></tr></thead><tbody><tr><td>Jaeyeong</td></tr></tbody></table></td>',
+    );
+  });
+
+  it("'none' hides the front matter entirely", async () => {
+    const html = await parse('none', frontMatter);
+
+    expect(html).not.toContain('Hello World');
+    expect(html).not.toContain('<table>');
+    expect(html).toContain('Body text.');
+  });
+
+  it("'code block' renders the front matter as a yaml code block", async () => {
+    const html = await parse('code block', frontMatter);
+
+    expect(html).toContain('data-role="codeBlock" data-info="yaml"');
+    expect(html).toContain('Hello World');
+    expect(html).not.toContain('<table>');
+  });
+
+  it('escapes html in keys and values', async () => {
+    const html = await parse('vertical table', '---\nx<script>: a<b\n---\n');
+
+    expect(html).toContain('<tr><th>x&lt;script&gt;</th><td>a&lt;b</td></tr>');
+    expect(html).not.toContain('<script>');
+  });
+});


### PR DESCRIPTION
## What

Adds a `'vertical table'` value to `frontMatterRenderingOption`, fixing [vscode-mpe#2371](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2371): with the existing `'table'` layout each front matter key becomes a column, so documents with many keys or long values produce a table wider than the preview pane that requires horizontal scrolling. `'vertical table'` renders one key/value pair per row (`<tr><th>key</th><td>value</td></tr>`) — the layout VS Code's built-in preview uses.

## Details

- `frontMatterToTable(arg, vertical)` — vertical mode emits a `<tbody>` of key/value rows (no `<thead>`); nested objects recurse vertically, array values stay a single row of cells.
- Dispatch follows the existing first-letter idiom (`'t'` → table, `'v'` → vertical table), so the historical tolerance for host spellings like `'code block'` is preserved; the two table branches share one code path.
- `FrontMatterRenderingOption` type now documents all real-world values: `'none' | 'table' | 'vertical table' | 'code' | 'code block'`.
- Keys and values go through the same `escape()` as before.

## Tests

New `test/front-matter-table.test.ts` (5 cases): vertical layout markup incl. nested objects/arrays, unchanged horizontal layout, `'none'`, `'code block'`, and HTML escaping of keys/values. Full suite: 643 passing.

Companion extension PR exposes the setting value in VS Code (enum + localized descriptions).