### PR TITLE
fix(notebook): stop deleteNote(path, true) from unlinking files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please visit https://github.com/shd101wyy/vscode-markdown-preview-enhanced/relea
 
 ## [Unreleased]
 
+### Bug fixes
+
+- **`deleteNote(path, true)` no longer deletes a file that exists at the path** — the `alreadyDeleted` flag was wired backwards: passing `true` (which Markdown Preview Enhanced's file watcher does for every deletion event) guaranteed the `unlink()` branch ran instead of skipping it. When Git removed and then recreated a Markdown file during a branch checkout, the watcher's delayed deletion notification deleted the freshly recreated replacement — data loss that surfaced as unstaged deletions in `git status`. In the common case where the file really was gone, `unlink()` also rejected with ENOENT before the note's relations and search entry were cleaned up. `deleteNote` now only unlinks when asked to perform the deletion itself (`alreadyDeleted: false` and the file still exists); the internal bookkeeping always runs ([#481](https://github.com/shd101wyy/crossnote/issues/481) reported by @Josh-Cena).
+
 ## [0.9.33] - 2026-09-01
 
 ### Features

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -1399,13 +1399,23 @@ export class Notebook {
     delete this.notes[note.filePath];
   }
 
+  /**
+   * Delete a note and update the internal note relations and search index.
+   *
+   * @param filePath Note to delete.
+   * @param alreadyDeleted Set to `true` when the caller has already removed
+   *   the file from disk (e.g. a filesystem watcher reacting to a deletion
+   *   event). In that case the file is left untouched — a replacement file
+   *   recreated at the same path (e.g. by a Git checkout) must survive —
+   *   and only the internal bookkeeping is refreshed.
+   */
   public async deleteNote(filePath: string, alreadyDeleted: boolean = false) {
     const absFilePath = this.resolveNoteAbsolutePath(filePath);
-    if (alreadyDeleted || (await this.fs.exists(absFilePath))) {
+    if (!alreadyDeleted && (await this.fs.exists(absFilePath))) {
       await this.fs.unlink(absFilePath);
-      await this.removeNoteRelations(filePath);
-      this.search.remove(filePath);
     }
+    await this.removeNoteRelations(filePath);
+    this.search.remove(filePath);
   }
 
   /**

--- a/test/notebook-delete-note.test.ts
+++ b/test/notebook-delete-note.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for #481: `deleteNote(path, true)` used to unlink the
+ * path even though the second argument means "the caller already deleted
+ * the file". When Git removed and then recreated a file during a checkout,
+ * the delayed deletion notification from the file watcher deleted the
+ * replacement file — data loss reported as unstaged deletions in
+ * `git status`.
+ */
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Notebook } from '../src/notebook';
+
+describe('Notebook.deleteNote', () => {
+  let notebookPath: string;
+
+  beforeEach(async () => {
+    const base = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'crossnote-delete-note-'),
+    );
+    notebookPath = base;
+    await fs.writeFile(path.join(notebookPath, 'note.md'), '# My Note\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(notebookPath, { recursive: true, force: true });
+  });
+
+  async function loadedNotebook(): Promise<Notebook> {
+    const nb = await Notebook.init({
+      notebookPath,
+      config: { markdownParser: 'markdown-it' },
+    });
+    await nb.refreshNotes({ dir: '.', includeSubdirectories: true });
+    return nb;
+  }
+
+  test('alreadyDeleted: true keeps a file that exists at the path (e.g. recreated by Git)', async () => {
+    const nb = await loadedNotebook();
+    expect(nb.notes['note.md']).toBeTruthy();
+
+    await nb.deleteNote('note.md', true);
+
+    // The file must survive — only the internal bookkeeping is refreshed.
+    expect(await fs.readFile(path.join(notebookPath, 'note.md'), 'utf8')).toBe(
+      '# My Note\n',
+    );
+    expect(nb.notes['note.md']).toBeUndefined();
+  });
+
+  test('alreadyDeleted: true on a missing file resolves without throwing', async () => {
+    const nb = await loadedNotebook();
+    await fs.rm(path.join(notebookPath, 'note.md'));
+
+    await expect(nb.deleteNote('note.md', true)).resolves.toBeUndefined();
+    expect(nb.notes['note.md']).toBeUndefined();
+  });
+
+  test('alreadyDeleted: false (default) deletes the file from disk', async () => {
+    const nb = await loadedNotebook();
+
+    await nb.deleteNote('note.md');
+
+    await expect(fs.stat(path.join(notebookPath, 'note.md'))).rejects.toThrow();
+    expect(nb.notes['note.md']).toBeUndefined();
+  });
+
+  test('alreadyDeleted: false on a missing file resolves without throwing', async () => {
+    const nb = await loadedNotebook();
+    await fs.rm(path.join(notebookPath, 'note.md'));
+
+    await expect(nb.deleteNote('note.md')).resolves.toBeUndefined();
+    expect(nb.notes['note.md']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #481.

`Notebook.deleteNote(filePath, alreadyDeleted)` had its flag wired backwards: `alreadyDeleted: true` **guaranteed** the `unlink()` branch ran instead of skipping it. Markdown Preview Enhanced's file watcher calls `deleteNote(path, true)` for every deletion event, so:

- **Data loss during Git checkouts** — when Git removed a Markdown file and then recreated it while updating the working tree (branch switch, `gh pr checkout`), the watcher's delayed deletion notification deleted the freshly recreated replacement. This surfaced as unstaged deletions in `git status` (46 files in one reproduction on mdn/content) and never happened with VS Code closed.
- **ENOENT in the common case** — when the file really was gone, `unlink()` rejected before `removeNoteRelations()` and `search.remove()` could run, leaving note relations and the search index stale (and the watcher callback's promise rejected).

## Changes

- `deleteNote()` now only unlinks when asked to perform the deletion itself (`alreadyDeleted: false` **and** the file still exists); the internal bookkeeping (note relations + search index) always runs, making the call idempotent for already-missing files. A doc comment spells out the parameter's contract.
- New regression suite `test/notebook-delete-note.test.ts` covering all four combinations of `alreadyDeleted` × file-exists. The key test asserts a file present at the path survives `deleteNote(path, true)`; it was verified to fail against the previous implementation.
- CHANGELOG entry under `[Unreleased]`.

## Testing

- [x] New regression tests pass, and fail against the pre-fix code
- [x] `pnpm check` (ESLint + Prettier + tsc)
- [x] `pnpm test` — 50 suites, 688 tests
- [x] `pnpm build`
